### PR TITLE
Some more polishing of the wires refactor

### DIFF
--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -46,7 +46,9 @@ class CirqDevice(QubitDevice, abc.ABC):
     """Abstract base device for PennyLane-Cirq.
 
     Args:
-        wires (int): the number of wires to initialize the device with
+        wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,
+            or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
+            or strings (``['ancilla', 'q1', 'q2']``).
         shots (int): Number of circuit evaluations/random samples used
             to estimate expectation values of observables. Shots need to be >= 1.
         qubits (List[cirq.Qubit]): a list of Cirq qubits that are used
@@ -55,7 +57,7 @@ class CirqDevice(QubitDevice, abc.ABC):
     """
 
     name = "Cirq Abstract PennyLane plugin baseclass"
-    pennylane_requires = ">=0.9.0"
+    pennylane_requires = ">=0.11.0"
     version = __version__
     author = "Xanadu Inc"
     _capabilities = {

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -44,7 +44,9 @@ class SimulatorDevice(CirqDevice):
     r"""Cirq simulator device for PennyLane.
 
     Args:
-        wires (int): the number of wires to initialize the device with
+        wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,
+            or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
+            or strings (``['ancilla', 'q1', 'q2']``).
         shots (int): Number of circuit evaluations/random samples used
             to estimate expectation values of observables. Shots need
             to >= 1. In analytic mode, shots indicates the number of entries
@@ -143,9 +145,7 @@ class SimulatorDevice(CirqDevice):
         if self._state is None:
             return None
 
-        wires = wires or range(self.num_wires)
         probs = self._get_computational_basis_probs()
-
         return self.marginal_prob(probs, wires)
 
     @staticmethod
@@ -190,7 +190,9 @@ class MixedStateSimulatorDevice(SimulatorDevice):
     r"""Cirq mixed-state simulator device for PennyLane.
 
     Args:
-        wires (int): the number of wires to initialize the device with
+        wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,
+            or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
+            or strings (``['ancilla', 'q1', 'q2']``).
         shots (int): Number of circuit evaluations/random samples used
             to estimate expectation values of observables. Shots need
             to >= 1. In analytic mode, shots indicates the number of entries


### PR DESCRIPTION
This PR adds some items missing in the wires refactor PR #37  :

- update some device docstrings
- update required PL version
- delete superfluous (and in fact wrong) line in analytic_probabilities