### PR TITLE
Remove import of qsimcirq from `__init__`

### DIFF
--- a/pennylane_cirq/__init__.py
+++ b/pennylane_cirq/__init__.py
@@ -16,7 +16,6 @@ Plugin overview
 ===============
 """
 from .simulator_device import SimulatorDevice, MixedStateSimulatorDevice
-from .qsim_device import QSimDevice, QSimhDevice
 from .pasqal_device import PasqalDevice
 
 from .ops import BitFlip, PhaseFlip, PhaseDamp, AmplitudeDamp, Depolarize, ISWAP, CPhase

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ info = {
     "packages": ["pennylane_cirq"],
     "entry_points": {"pennylane.plugins": ["cirq.simulator = pennylane_cirq:SimulatorDevice",
                                            "cirq.mixedsimulator = pennylane_cirq:MixedStateSimulatorDevice",
-                                           "cirq.qsim = pennylane_cirq:QSimDevice",
-                                           "cirq.qsimh = pennylane_cirq:QSimhDevice",
+                                           "cirq.qsim = pennylane_cirq.qsim_device:QSimDevice",
+                                           "cirq.qsimh = pennylane_cirq.qsim_device:QSimhDevice",
                                            "cirq.pasqal = pennylane_cirq:PasqalDevice"],},
     # Place a one line description here. This will be shown by pip
     "description": "PennyLane plugin for Cirq",

--- a/tests/test_qsim_device.py
+++ b/tests/test_qsim_device.py
@@ -19,8 +19,7 @@ import math
 
 import pennylane as qml
 import numpy as np
-from pennylane_cirq import QSimDevice
-import cirq
+from pennylane_cirq.qsim_device import QSimDevice
 
 
 class TestDeviceIntegration:

--- a/tests/test_qsimh_device.py
+++ b/tests/test_qsimh_device.py
@@ -19,8 +19,7 @@ import math
 
 import pennylane as qml
 import numpy as np
-from pennylane_cirq import QSimhDevice
-import cirq
+from pennylane_cirq.qsim_device import QSimhDevice
 
 qsimh_options = {"k": [0], "w": 0, "p": 0, "r": 0}
 


### PR DESCRIPTION
Removes the import of `qsimcirq` from the `__init__.py` file and fixes the tests and entrypoints to import qsimcirq correctly.

This avoids users having to install `qsimcirq` for the other Cirq devices to work.