### PR TITLE
Replace cirq.rx etc by XPowGate etc.

### DIFF
--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -142,7 +142,6 @@ class CirqDevice(QubitDevice, abc.ABC):
         "RX": CirqOperation(lambda phi: cirq.XPowGate(exponent=phi / np.pi, global_shift=-0.5)),
         "RY": CirqOperation(lambda phi: cirq.YPowGate(exponent=phi / np.pi, global_shift=-0.5)),
         "RZ": CirqOperation(lambda phi: cirq.ZPowGate(exponent=phi / np.pi, global_shift=-0.5)),
-cirq.ZPowGate(exponent=a / np.pi, global_shift=-0.5)
         "Rot": CirqOperation(lambda a, b, c: [cirq.ZPowGate(exponent=a / np.pi, global_shift=-0.5), cirq.YPowGate(exponent=b / np.pi, global_shift=-0.5), cirq.ZPowGate(exponent=c / np.pi, global_shift=-0.5)]),
         "CRX": CirqOperation(lambda phi: cirq.ControlledGate(cirq.XPowGate(exponent=phi / np.pi, global_shift=-0.5))),
         "CRY": CirqOperation(lambda phi: cirq.ControlledGate(cirq.YPowGate(exponent=phi / np.pi, global_shift=-0.5))),

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -143,9 +143,9 @@ class CirqDevice(QubitDevice, abc.ABC):
         "RY": CirqOperation(lambda phi: cirq.YPowGate(exponent=phi / np.pi, global_shift=-0.5)),
         "RZ": CirqOperation(lambda phi: cirq.ZPowGate(exponent=phi / np.pi, global_shift=-0.5)),
         "Rot": CirqOperation(lambda a, b, c: [cirq.ZPowGate(exponent=a / np.pi, global_shift=-0.5), cirq.YPowGate(exponent=b / np.pi, global_shift=-0.5), cirq.ZPowGate(exponent=c / np.pi, global_shift=-0.5)]),
-        "CRX": CirqOperation(lambda phi: cirq.ControlledGate(cirq.XPowGate(exponent=phi / np.pi, global_shift=-0.5))),
-        "CRY": CirqOperation(lambda phi: cirq.ControlledGate(cirq.YPowGate(exponent=phi / np.pi, global_shift=-0.5))),
-        "CRZ": CirqOperation(lambda phi: cirq.ControlledGate(cirq.ZPowGate(exponent=phi / np.pi, global_shift=-0.5))),
+        "CRX": CirqOperation(lambda phi: cirq.CNotPowGate(exponent=phi / np.pi, global_shift=-0.5)),
+        "CRY": CirqOperation(lambda phi: cirq.ControlledGate(cirq.CYPowGate(exponent=phi / np.pi, global_shift=-0.5))),
+        "CRZ": CirqOperation(lambda phi: cirq.CZPowGate(exponent=phi / np.pi, global_shift=-0.5)),
         "CRot": CirqOperation(
             lambda a, b, c: [
                 cirq.ControlledGate(cirq.rz(a)),

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -144,7 +144,7 @@ class CirqDevice(QubitDevice, abc.ABC):
         "RZ": CirqOperation(lambda phi: cirq.ZPowGate(exponent=phi / np.pi, global_shift=-0.5)),
         "Rot": CirqOperation(lambda a, b, c: [cirq.ZPowGate(exponent=a / np.pi, global_shift=-0.5), cirq.YPowGate(exponent=b / np.pi, global_shift=-0.5), cirq.ZPowGate(exponent=c / np.pi, global_shift=-0.5)]),
         "CRX": CirqOperation(lambda phi: cirq.CNotPowGate(exponent=phi / np.pi, global_shift=-0.5)),
-        "CRY": CirqOperation(lambda phi: cirq.ControlledGate(cirq.CYPowGate(exponent=phi / np.pi, global_shift=-0.5))),
+        "CRY": CirqOperation(lambda phi: cirq.ControlledGate(cirq.YPowGate(exponent=phi / np.pi, global_shift=-0.5))),
         "CRZ": CirqOperation(lambda phi: cirq.CZPowGate(exponent=phi / np.pi, global_shift=-0.5)),
         "CRot": CirqOperation(
             lambda a, b, c: [

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -139,19 +139,19 @@ class CirqDevice(QubitDevice, abc.ABC):
         "CZ": CirqOperation(lambda: cirq.CZ),
         "PhaseShift": CirqOperation(lambda phi: cirq.ZPowGate(exponent=phi / np.pi)),
         "CPhase": CirqOperation(lambda phi: cirq.CZPowGate(exponent=phi / np.pi)),
-        "RX": CirqOperation(lambda phi: cirq.XPowGate(exponent=phi / np.pi, global_shift=-0.5)),
-        "RY": CirqOperation(lambda phi: cirq.YPowGate(exponent=phi / np.pi, global_shift=-0.5)),
-        "RZ": CirqOperation(lambda phi: cirq.ZPowGate(exponent=phi / np.pi, global_shift=-0.5)),
+        "RX": CirqOperation(lambda phi: cirq.XPowGate(exponent=phi / np.pi, global_shift=0.5)),
+        "RY": CirqOperation(lambda phi: cirq.YPowGate(exponent=phi / np.pi, global_shift=0.5)),
+        "RZ": CirqOperation(lambda phi: cirq.ZPowGate(exponent=phi / np.pi, global_shift=0.5)),
         "Rot": CirqOperation(
             lambda a, b, c: [
-                cirq.ZPowGate(exponent=a / np.pi, global_shift=-0.5),
-                cirq.YPowGate(exponent=b / np.pi, global_shift=-0.5),
-                cirq.ZPowGate(exponent=c / np.pi, global_shift=-0.5),
+                cirq.ZPowGate(exponent=a / np.pi, global_shift=0.5),
+                cirq.YPowGate(exponent=b / np.pi, global_shift=0.5),
+                cirq.ZPowGate(exponent=c / np.pi, global_shift=0.5),
             ]
         ),
-        "CRX": CirqOperation(lambda phi: cirq.CNotPowGate(exponent=phi / np.pi, global_shift=-0.5)),
+        "CRX": CirqOperation(lambda phi: cirq.CNotPowGate(exponent=phi / np.pi, global_shift=0.5)),
         # "CRY": CirqOperation(lambda phi: cirq.ControlledGate(cirq.YPowGate(exponent=phi / np.pi, global_shift=-0.5))),
-        "CRZ": CirqOperation(lambda phi: cirq.CZPowGate(exponent=phi / np.pi, global_shift=-0.5)),
+        "CRZ": CirqOperation(lambda phi: cirq.CZPowGate(exponent=phi / np.pi, global_shift=0.5)),
         # "CRot": CirqOperation(
         # lambda a, b, c: [
         # cirq.ControlledGate(cirq.rz(a)),

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -142,17 +142,23 @@ class CirqDevice(QubitDevice, abc.ABC):
         "RX": CirqOperation(lambda phi: cirq.XPowGate(exponent=phi / np.pi, global_shift=-0.5)),
         "RY": CirqOperation(lambda phi: cirq.YPowGate(exponent=phi / np.pi, global_shift=-0.5)),
         "RZ": CirqOperation(lambda phi: cirq.ZPowGate(exponent=phi / np.pi, global_shift=-0.5)),
-        "Rot": CirqOperation(lambda a, b, c: [cirq.ZPowGate(exponent=a / np.pi, global_shift=-0.5), cirq.YPowGate(exponent=b / np.pi, global_shift=-0.5), cirq.ZPowGate(exponent=c / np.pi, global_shift=-0.5)]),
+        "Rot": CirqOperation(
+            lambda a, b, c: [
+                cirq.ZPowGate(exponent=a / np.pi, global_shift=-0.5),
+                cirq.YPowGate(exponent=b / np.pi, global_shift=-0.5),
+                cirq.ZPowGate(exponent=c / np.pi, global_shift=-0.5),
+            ]
+        ),
         "CRX": CirqOperation(lambda phi: cirq.CNotPowGate(exponent=phi / np.pi, global_shift=-0.5)),
-        #"CRY": CirqOperation(lambda phi: cirq.ControlledGate(cirq.YPowGate(exponent=phi / np.pi, global_shift=-0.5))),
+        # "CRY": CirqOperation(lambda phi: cirq.ControlledGate(cirq.YPowGate(exponent=phi / np.pi, global_shift=-0.5))),
         "CRZ": CirqOperation(lambda phi: cirq.CZPowGate(exponent=phi / np.pi, global_shift=-0.5)),
-        #"CRot": CirqOperation(
-            #lambda a, b, c: [
-                #cirq.ControlledGate(cirq.rz(a)),
-                #cirq.ControlledGate(cirq.ry(b)),
-                #cirq.ControlledGate(cirq.rz(c)),
-            #]
-        #),
+        # "CRot": CirqOperation(
+        # lambda a, b, c: [
+        # cirq.ControlledGate(cirq.rz(a)),
+        # cirq.ControlledGate(cirq.ry(b)),
+        # cirq.ControlledGate(cirq.rz(c)),
+        # ]
+        # ),
         "CSWAP": CirqOperation(lambda: cirq.CSWAP),
         "Toffoli": CirqOperation(lambda: cirq.TOFFOLI),
     }

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -139,13 +139,14 @@ class CirqDevice(QubitDevice, abc.ABC):
         "CZ": CirqOperation(lambda: cirq.CZ),
         "PhaseShift": CirqOperation(lambda phi: cirq.ZPowGate(exponent=phi / np.pi)),
         "CPhase": CirqOperation(lambda phi: cirq.CZPowGate(exponent=phi / np.pi)),
-        "RX": CirqOperation(cirq.rx),
-        "RY": CirqOperation(cirq.ry),
-        "RZ": CirqOperation(cirq.rz),
-        "Rot": CirqOperation(lambda a, b, c: [cirq.rz(a), cirq.ry(b), cirq.rz(c)]),
-        "CRX": CirqOperation(lambda phi: cirq.ControlledGate(cirq.rx(phi))),
-        "CRY": CirqOperation(lambda phi: cirq.ControlledGate(cirq.ry(phi))),
-        "CRZ": CirqOperation(lambda phi: cirq.ControlledGate(cirq.rz(phi))),
+        "RX": CirqOperation(lambda phi: cirq.XPowGate(exponent=phi / np.pi, global_shift=-0.5)),
+        "RY": CirqOperation(lambda phi: cirq.YPowGate(exponent=phi / np.pi, global_shift=-0.5)),
+        "RZ": CirqOperation(lambda phi: cirq.ZPowGate(exponent=phi / np.pi, global_shift=-0.5)),
+cirq.ZPowGate(exponent=a / np.pi, global_shift=-0.5)
+        "Rot": CirqOperation(lambda a, b, c: [cirq.ZPowGate(exponent=a / np.pi, global_shift=-0.5), cirq.YPowGate(exponent=b / np.pi, global_shift=-0.5), cirq.ZPowGate(exponent=c / np.pi, global_shift=-0.5)]),
+        "CRX": CirqOperation(lambda phi: cirq.ControlledGate(cirq.XPowGate(exponent=phi / np.pi, global_shift=-0.5))),
+        "CRY": CirqOperation(lambda phi: cirq.ControlledGate(cirq.YPowGate(exponent=phi / np.pi, global_shift=-0.5))),
+        "CRZ": CirqOperation(lambda phi: cirq.ControlledGate(cirq.ZPowGate(exponent=phi / np.pi, global_shift=-0.5))),
         "CRot": CirqOperation(
             lambda a, b, c: [
                 cirq.ControlledGate(cirq.rz(a)),

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -144,15 +144,15 @@ class CirqDevice(QubitDevice, abc.ABC):
         "RZ": CirqOperation(lambda phi: cirq.ZPowGate(exponent=phi / np.pi, global_shift=-0.5)),
         "Rot": CirqOperation(lambda a, b, c: [cirq.ZPowGate(exponent=a / np.pi, global_shift=-0.5), cirq.YPowGate(exponent=b / np.pi, global_shift=-0.5), cirq.ZPowGate(exponent=c / np.pi, global_shift=-0.5)]),
         "CRX": CirqOperation(lambda phi: cirq.CNotPowGate(exponent=phi / np.pi, global_shift=-0.5)),
-        "CRY": CirqOperation(lambda phi: cirq.ControlledGate(cirq.YPowGate(exponent=phi / np.pi, global_shift=-0.5))),
+        #"CRY": CirqOperation(lambda phi: cirq.ControlledGate(cirq.YPowGate(exponent=phi / np.pi, global_shift=-0.5))),
         "CRZ": CirqOperation(lambda phi: cirq.CZPowGate(exponent=phi / np.pi, global_shift=-0.5)),
-        "CRot": CirqOperation(
-            lambda a, b, c: [
-                cirq.ControlledGate(cirq.rz(a)),
-                cirq.ControlledGate(cirq.ry(b)),
-                cirq.ControlledGate(cirq.rz(c)),
-            ]
-        ),
+        #"CRot": CirqOperation(
+            #lambda a, b, c: [
+                #cirq.ControlledGate(cirq.rz(a)),
+                #cirq.ControlledGate(cirq.ry(b)),
+                #cirq.ControlledGate(cirq.rz(c)),
+            #]
+        #),
         "CSWAP": CirqOperation(lambda: cirq.CSWAP),
         "Toffoli": CirqOperation(lambda: cirq.TOFFOLI),
     }


### PR DESCRIPTION
This will enable floq to use qml.RX, qml.RY, qml.RZ, qml.CRX, qml.CRZ via the PowGates instead of the corresponding cirq implementations or RX etc, which do not work with floq.
CRY and CRot will not work unless one explicitly decomposes them or implements CYPowGate (for both).
In order to make the gates work, I commented out the corresponding operations in the device such that they should be decomposed by pennylane.