### PR TITLE
Add a projector observable to CirqDevice

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
       - name: Cancel Previous Runs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## New features
 
-* Added Projector observable to CirqDevice.
+* Added support for the new `qml.Projector` observable in
+  PennyLane v0.16 to the Cirq devices.
   [(#62)](https://github.com/PennyLaneAI/pennylane-cirq/pull/62)
 
 ## Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## New features
 
+* Added Projector observable to CirqDevice.
+  [(#62)](https://github.com/PennyLaneAI/pennylane-cirq/pull/62)
+
 ## Improvements
 
 ## Bug fixes
@@ -13,6 +16,8 @@
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Vincent Wong
 
 ---
 

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -166,7 +166,7 @@ class CirqDevice(QubitDevice, abc.ABC):
         # to support this observable.
         "Hermitian": None,
         "Identity": CirqOperation(lambda: cirq.I),
-        "Projector": CirqOperation(lambda: cirq.ProductState.projector)
+        "Projector": CirqOperation(lambda: cirq.ProductState.projector),
     }
 
     def to_paulistring(self, observable):

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -166,6 +166,7 @@ class CirqDevice(QubitDevice, abc.ABC):
         # to support this observable.
         "Hermitian": None,
         "Identity": CirqOperation(lambda: cirq.I),
+        "Projector": CirqOperation(lambda: cirq.ProductState.projector)
     }
 
     def to_paulistring(self, observable):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pennylane>=0.15
+git+https://github.com/PennyLaneAI/pennylane.git
 cirq>=0.10
 numpy~=1.16

--- a/tests/test_expval.py
+++ b/tests/test_expval.py
@@ -437,28 +437,36 @@ class TestTensorExpval:
                 ]
             )
 
-        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Projector([0, 0], wires=[1, 2], do_queue=False)
+        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Projector(
+            [0, 0], wires=[1, 2], do_queue=False
+        )
         res = dev.expval(obs)
         expected = (np.cos(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2 - (
             np.cos(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)
         ) ** 2
         assert np.allclose(res, expected, **tol)
 
-        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Projector([0, 1], wires=[1, 2], do_queue=False)
+        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Projector(
+            [0, 1], wires=[1, 2], do_queue=False
+        )
         res = dev.expval(obs)
         expected = (np.sin(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2 - (
             np.sin(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)
         ) ** 2
         assert np.allclose(res, expected, **tol)
 
-        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Projector([1, 0], wires=[1, 2], do_queue=False)
+        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Projector(
+            [1, 0], wires=[1, 2], do_queue=False
+        )
         res = dev.expval(obs)
         expected = (np.sin(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2 - (
             np.sin(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)
         ) ** 2
         assert np.allclose(res, expected, **tol)
 
-        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Projector([1, 1], wires=[1, 2], do_queue=False)
+        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Projector(
+            [1, 1], wires=[1, 2], do_queue=False
+        )
         res = dev.expval(obs)
         expected = (np.cos(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2 - (
             np.cos(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)

--- a/tests/test_expval.py
+++ b/tests/test_expval.py
@@ -48,7 +48,11 @@ class TestExpval:
 
         with mimic_execution_for_expval(dev):
             dev.apply(
-                [qml.RX(theta, wires=[0]), qml.RX(phi, wires=[1]), qml.CNOT(wires=[0, 1]),]
+                [
+                    qml.RX(theta, wires=[0]),
+                    qml.RX(phi, wires=[1]),
+                    qml.CNOT(wires=[0, 1]),
+                ]
             )
 
         O = qml.Identity
@@ -57,7 +61,10 @@ class TestExpval:
         dev._obs_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
 
         res = np.array(
-            [dev.expval(O(wires=[0], do_queue=False)), dev.expval(O(wires=[1], do_queue=False)),]
+            [
+                dev.expval(O(wires=[0], do_queue=False)),
+                dev.expval(O(wires=[1], do_queue=False)),
+            ]
         )
 
         assert np.allclose(res, np.array([1, 1]), **tol)
@@ -71,7 +78,11 @@ class TestExpval:
 
         with mimic_execution_for_expval(dev):
             dev.apply(
-                [qml.RX(theta, wires=[0]), qml.RX(phi, wires=[1]), qml.CNOT(wires=[0, 1]),]
+                [
+                    qml.RX(theta, wires=[0]),
+                    qml.RX(phi, wires=[1]),
+                    qml.CNOT(wires=[0, 1]),
+                ]
             )
 
         O = qml.PauliZ
@@ -80,7 +91,10 @@ class TestExpval:
         dev._obs_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
 
         res = np.array(
-            [dev.expval(O(wires=[0], do_queue=False)), dev.expval(O(wires=[1], do_queue=False)),]
+            [
+                dev.expval(O(wires=[0], do_queue=False)),
+                dev.expval(O(wires=[1], do_queue=False)),
+            ]
         )
 
         assert np.allclose(res, np.array([np.cos(theta), np.cos(theta) * np.cos(phi)]), **tol)
@@ -95,7 +109,11 @@ class TestExpval:
 
         with mimic_execution_for_expval(dev):
             dev.apply(
-                [qml.RY(theta, wires=[0]), qml.RY(phi, wires=[1]), qml.CNOT(wires=[0, 1]),],
+                [
+                    qml.RY(theta, wires=[0]),
+                    qml.RY(phi, wires=[1]),
+                    qml.CNOT(wires=[0, 1]),
+                ],
                 rotations=O(wires=[0], do_queue=False).diagonalizing_gates()
                 + O(wires=[1], do_queue=False).diagonalizing_gates(),
             )
@@ -103,7 +121,10 @@ class TestExpval:
         dev._obs_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
 
         res = np.array(
-            [dev.expval(O(wires=[0], do_queue=False)), dev.expval(O(wires=[1], do_queue=False)),]
+            [
+                dev.expval(O(wires=[0], do_queue=False)),
+                dev.expval(O(wires=[1], do_queue=False)),
+            ]
         )
         assert np.allclose(res, np.array([np.sin(theta) * np.sin(phi), np.sin(phi)]), **tol)
 
@@ -117,7 +138,11 @@ class TestExpval:
 
         with mimic_execution_for_expval(dev):
             dev.apply(
-                [qml.RX(theta, wires=[0]), qml.RX(phi, wires=[1]), qml.CNOT(wires=[0, 1]),],
+                [
+                    qml.RX(theta, wires=[0]),
+                    qml.RX(phi, wires=[1]),
+                    qml.CNOT(wires=[0, 1]),
+                ],
                 rotations=O(wires=[0], do_queue=False).diagonalizing_gates()
                 + O(wires=[1], do_queue=False).diagonalizing_gates(),
             )
@@ -125,7 +150,10 @@ class TestExpval:
         dev._obs_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
 
         res = np.array(
-            [dev.expval(O(wires=[0], do_queue=False)), dev.expval(O(wires=[1], do_queue=False)),]
+            [
+                dev.expval(O(wires=[0], do_queue=False)),
+                dev.expval(O(wires=[1], do_queue=False)),
+            ]
         )
         assert np.allclose(res, np.array([0, -(np.cos(theta)) * np.sin(phi)]), **tol)
 
@@ -139,7 +167,11 @@ class TestExpval:
 
         with mimic_execution_for_expval(dev):
             dev.apply(
-                [qml.RY(theta, wires=[0]), qml.RY(phi, wires=[1]), qml.CNOT(wires=[0, 1]),],
+                [
+                    qml.RY(theta, wires=[0]),
+                    qml.RY(phi, wires=[1]),
+                    qml.CNOT(wires=[0, 1]),
+                ],
                 rotations=O(wires=[0], do_queue=False).diagonalizing_gates()
                 + O(wires=[1], do_queue=False).diagonalizing_gates(),
             )
@@ -147,14 +179,20 @@ class TestExpval:
         dev._obs_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
 
         res = np.array(
-            [dev.expval(O(wires=[0], do_queue=False)), dev.expval(O(wires=[1], do_queue=False)),]
-        )
-        expected = np.array(
             [
-                np.sin(theta) * np.sin(phi) + np.cos(theta),
-                np.cos(theta) * np.cos(phi) + np.sin(phi),
+                dev.expval(O(wires=[0], do_queue=False)),
+                dev.expval(O(wires=[1], do_queue=False)),
             ]
-        ) / np.sqrt(2)
+        )
+        expected = (
+            np.array(
+                [
+                    np.sin(theta) * np.sin(phi) + np.cos(theta),
+                    np.cos(theta) * np.cos(phi) + np.sin(phi),
+                ]
+            )
+            / np.sqrt(2)
+        )
         assert np.allclose(res, expected, **tol)
 
     def test_hermitian_expectation(self, device, shots, tol):
@@ -167,7 +205,11 @@ class TestExpval:
 
         with mimic_execution_for_expval(dev):
             dev.apply(
-                [qml.RY(theta, wires=[0]), qml.RY(phi, wires=[1]), qml.CNOT(wires=[0, 1]),],
+                [
+                    qml.RY(theta, wires=[0]),
+                    qml.RY(phi, wires=[1]),
+                    qml.CNOT(wires=[0, 1]),
+                ],
                 rotations=O(A, wires=[0], do_queue=False).diagonalizing_gates()
                 + O(A, wires=[1], do_queue=False).diagonalizing_gates(),
             )
@@ -203,7 +245,11 @@ class TestExpval:
 
         with mimic_execution_for_expval(dev):
             dev.apply(
-                [qml.RY(theta, wires=[0]), qml.RY(phi, wires=[1]), qml.CNOT(wires=[0, 1]),],
+                [
+                    qml.RY(theta, wires=[0]),
+                    qml.RY(phi, wires=[1]),
+                    qml.CNOT(wires=[0, 1]),
+                ],
                 rotations=O(B, wires=[0, 1], do_queue=False).diagonalizing_gates(),
             )
 
@@ -233,10 +279,16 @@ class TestExpval:
 
         with mimic_execution_for_expval(dev):
             dev.apply(
-                [qml.RY(theta, wires=[0]), qml.RY(phi, wires=[1]), qml.CNOT(wires=[0, 1]),]
+                [
+                    qml.RY(theta, wires=[0]),
+                    qml.RY(phi, wires=[1]),
+                    qml.CNOT(wires=[0, 1]),
+                ]
             )
 
-        dev._obs_queue = [O([0, 0], wires=[0, 1], do_queue=False),]
+        dev._obs_queue = [
+            O([0, 0], wires=[0, 1], do_queue=False),
+        ]
 
         res = dev.expval(O([0, 0], wires=[0, 1], do_queue=False))
         expected = (np.cos(phi / 2) * np.cos(theta / 2)) ** 2

--- a/tests/test_expval.py
+++ b/tests/test_expval.py
@@ -223,6 +223,25 @@ class TestExpval:
 
         assert np.allclose(res, expected, **tol)
 
+    def test_projector_expectation(self, device, shots, tol):
+        """Test that arbitrary Projector expectation values are correct"""
+        theta = 0.732
+        phi = 0.523
+
+        dev = device(2)
+        O = qml.Projector
+
+        with mimic_execution_for_expval(dev):
+            dev.apply(
+                [qml.RY(theta, wires=[0]), qml.RY(phi, wires=[1]), qml.CNOT(wires=[0, 1]),]
+            )
+
+        dev._obs_queue = [O([0, 0], wires=[0, 1], do_queue=False),]
+
+        res = dev.expval(O([0, 0], wires=[0, 1], do_queue=False))
+        expected = (np.cos(phi / 2) * np.cos(theta / 2)) ** 2
+        assert np.allclose(res, expected, **tol)
+
 
 @pytest.mark.parametrize("shots", [None, 8192])
 class TestTensorExpval:

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -93,6 +93,36 @@ class TestSample:
         # the analytic variance is 0.25*(sin(theta)-4*cos(theta))^2
         assert np.allclose(np.var(s1), 0.25 * (np.sin(theta) - 4 * np.cos(theta)) ** 2, **tol)
 
+    def test_sample_values_projector(self, device, shots, tol):
+        """Tests if the samples of a Projector observable returned by sample have
+        the correct values
+        """
+        dev = device(1)
+
+        theta = 0.543
+
+        with mimic_execution_for_sample(dev):
+            dev.apply([qml.RX(theta, wires=[0])])
+
+        dev._obs_queue = [qml.Projector([0], wires=0, do_queue=False)]
+        dev._obs_queue[0].return_type = qml.operation.Sample
+        s1 = dev.sample(qml.Projector([0], wires=[0]))
+        # s1 should only contain 0 or 1, the eigenvalues of the projector
+        assert np.allclose(sorted(list(set(s1))), [0, 1], **tol)
+        assert np.allclose(np.mean(s1), np.cos(theta / 2) ** 2, **tol)
+        assert np.allclose(
+            np.var(s1), np.cos(theta / 2) ** 2 - (np.cos(theta / 2) ** 2) ** 2, **tol
+        )
+
+        dev._obs_queue = [qml.Projector([1], wires=0, do_queue=False)]
+        dev._obs_queue[0].return_type = qml.operation.Sample
+        s1 = dev.sample(qml.Projector([1], wires=[0]))
+        assert np.allclose(sorted(list(set(s1))), [0, 1], **tol)
+        assert np.allclose(np.mean(s1), np.sin(theta / 2) ** 2, **tol)
+        assert np.allclose(
+            np.var(s1), np.sin(theta / 2) ** 2 - (np.sin(theta / 2) ** 2) ** 2, **tol
+        )
+
     def test_sample_values_hermitian_multi_qubit(self, device, shots, tol):
         """Tests if the samples of a multi-qubit Hermitian observable returned by sample have
         the correct values
@@ -111,7 +141,11 @@ class TestSample:
 
         with mimic_execution_for_sample(dev):
             dev.apply(
-                [qml.RX(theta, wires=[0]), qml.RY(2 * theta, wires=[1]), qml.CNOT(wires=[0, 1]),],
+                [
+                    qml.RX(theta, wires=[0]),
+                    qml.RY(2 * theta, wires=[1]),
+                    qml.CNOT(wires=[0, 1]),
+                ],
                 rotations=qml.Hermitian(A, wires=[0, 1], do_queue=False).diagonalizing_gates(),
             )
 
@@ -137,6 +171,51 @@ class TestSample:
             + 27 * np.cos(3 * theta)
             + 6
         ) / 32
+        assert np.allclose(np.mean(s1), expected, **tol)
+
+    def test_sample_values_projector_multi_qubit(self, device, shots, tol):
+        """Tests if the samples of a multi-qubit Projector observable returned by sample have
+        the correct values
+        """
+        dev = device(2)
+        theta = 0.543
+
+        with mimic_execution_for_sample(dev):
+            dev.apply(
+                [
+                    qml.RX(theta, wires=[0]),
+                    qml.RY(2 * theta, wires=[1]),
+                    qml.CNOT(wires=[0, 1]),
+                ]
+            )
+
+        dev._obs_queue = [qml.Projector([0, 0], wires=[0, 1], do_queue=False)]
+        dev._obs_queue[0].return_type = qml.operation.Sample
+        s1 = dev.sample(qml.Projector([0, 0], wires=[0, 1]))
+        # s1 should only contain 0 or 1, the eigenvalues of the projector
+        assert np.allclose(sorted(list(set(s1))), [0, 1], **tol)
+        expected = (np.cos(theta / 2) * np.cos(theta)) ** 2
+        assert np.allclose(np.mean(s1), expected, **tol)
+
+        dev._obs_queue = [qml.Projector([0, 1], wires=[0, 1], do_queue=False)]
+        dev._obs_queue[0].return_type = qml.operation.Sample
+        s1 = dev.sample(qml.Projector([0, 1], wires=[0, 1]))
+        assert np.allclose(sorted(list(set(s1))), [0, 1], **tol)
+        expected = (np.cos(theta / 2) * np.sin(theta)) ** 2
+        assert np.allclose(np.mean(s1), expected, **tol)
+
+        dev._obs_queue = [qml.Projector([1, 0], wires=[0, 1], do_queue=False)]
+        dev._obs_queue[0].return_type = qml.operation.Sample
+        s1 = dev.sample(qml.Projector([1, 0], wires=[0, 1]))
+        assert np.allclose(sorted(list(set(s1))), [0, 1], **tol)
+        expected = (np.sin(theta / 2) * np.sin(theta)) ** 2
+        assert np.allclose(np.mean(s1), expected, **tol)
+
+        dev._obs_queue = [qml.Projector([1, 1], wires=[0, 1], do_queue=False)]
+        dev._obs_queue[0].return_type = qml.operation.Sample
+        s1 = dev.sample(qml.Projector([1, 1], wires=[0, 1]))
+        assert np.allclose(sorted(list(set(s1))), [0, 1], **tol)
+        expected = (np.sin(theta / 2) * np.cos(theta)) ** 2
         assert np.allclose(np.mean(s1), expected, **tol)
 
 

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -391,3 +391,114 @@ class TestTensorSample:
             )
         ) / 16
         assert np.allclose(var, expected, **tol)
+
+    def test_projector(self, device, shots, tol):  # WIP
+        """Test that a tensor product involving qml.Projector works correctly"""
+        theta = 0.832
+        phi = 0.123
+        varphi = -0.543
+
+        # Reseed here so that all eigenvalues are guaranteed to appear in the sample for all projected basis states
+        np.random.seed(8)
+
+        dev = device(3)
+
+        with mimic_execution_for_sample(dev):
+            dev.apply(
+                [
+                    qml.RX(theta, wires=[0]),
+                    qml.RX(phi, wires=[1]),
+                    qml.RX(varphi, wires=[2]),
+                    qml.CNOT(wires=[0, 1]),
+                    qml.CNOT(wires=[1, 2]),
+                ]
+            )
+
+        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Projector(
+            [0, 0], wires=[1, 2], do_queue=False
+        )
+        s1 = dev.sample(obs)
+        # s1 should only contain the eigenvalues of the projector matrix tensor product Z, i.e. {-1, 0, 1}
+        assert np.allclose(sorted(list(set(s1))), [-1, 0, 1], **tol)
+        mean = np.mean(s1)
+        expected = (np.cos(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2 - (
+            np.cos(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)
+        ) ** 2
+        assert np.allclose(mean, expected, **tol)
+        var = np.var(s1)
+        expected = (
+            (np.cos(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2
+            + (np.cos(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)) ** 2
+            - (
+                (np.cos(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2
+                - (np.cos(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)) ** 2
+            )
+            ** 2
+        )
+        assert np.allclose(var, expected, **tol)
+
+        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Projector(
+            [0, 1], wires=[1, 2], do_queue=False
+        )
+        s1 = dev.sample(obs)
+        assert np.allclose(sorted(list(set(s1))), [-1, 0, 1], **tol)
+        mean = np.mean(s1)
+        expected = (np.sin(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2 - (
+            np.sin(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)
+        ) ** 2
+        assert np.allclose(mean, expected, **tol)
+        var = np.var(s1)
+        expected = (
+            (np.sin(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2
+            + (np.sin(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)) ** 2
+            - (
+                (np.sin(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2
+                - (np.sin(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)) ** 2
+            )
+            ** 2
+        )
+        assert np.allclose(var, expected, **tol)
+
+        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Projector(
+            [1, 0], wires=[1, 2], do_queue=False
+        )
+        s1 = dev.sample(obs)
+        assert np.allclose(sorted(list(set(s1))), [-1, 0, 1], **tol)
+        mean = np.mean(s1)
+        expected = (np.sin(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2 - (
+            np.sin(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)
+        ) ** 2
+        assert np.allclose(mean, expected, **tol)
+        var = np.var(s1)
+        expected = (
+            (np.sin(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2
+            + (np.sin(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)) ** 2
+            - (
+                (np.sin(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2
+                - (np.sin(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)) ** 2
+            )
+            ** 2
+        )
+        assert np.allclose(var, expected, **tol)
+
+        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Projector(
+            [1, 1], wires=[1, 2], do_queue=False
+        )
+        s1 = dev.sample(obs)
+        assert np.allclose(sorted(list(set(s1))), [-1, 0, 1], **tol)
+        mean = np.mean(s1)
+        expected = (np.cos(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2 - (
+            np.cos(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)
+        ) ** 2
+        assert np.allclose(mean, expected, **tol)
+        var = np.var(s1)
+        expected = (
+            (np.cos(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2
+            + (np.cos(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)) ** 2
+            - (
+                (np.cos(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2
+                - (np.cos(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)) ** 2
+            )
+            ** 2
+        )
+        assert np.allclose(var, expected, **tol)


### PR DESCRIPTION
Context:
Adding a projector observable to CirqDevice.

Description of the Change:
Implementing projector observable with Cirq's own ```cirq.ProductState.projector``` method.

Related GitHub PR:
Work coherently with PR [#1356](https://github.com/PennyLaneAI/pennylane/pull/1356)