### PR TITLE
Fix bug for mixed simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## New features
 
-* Fix data type bug for mixed simulator using `QubitStateVector`.
-  [(#63)](https://github.com/PennyLaneAI/pennylane-cirq/pull/63)
-
 * Added support for the new `qml.Projector` observable in
   PennyLane v0.16 to the Cirq devices.
   [(#62)](https://github.com/PennyLaneAI/pennylane-cirq/pull/62)
@@ -12,6 +9,9 @@
 ## Improvements
 
 ## Bug fixes
+
+* Fix data type bug for mixed simulator when using `QubitStateVector`.
+  [(#63)](https://github.com/PennyLaneAI/pennylane-cirq/pull/63)
 
 * Fixed issue when using a subset of wires with `BasisState`.
   [(#61)](https://github.com/PennyLaneAI/pennylane-cirq/pull/61)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## New features
 
+* Fix data type bug for mixed simulator using `QubitStateVector`.
+  [(#63)](https://github.com/PennyLaneAI/pennylane-cirq/pull/63)
+
 * Added support for the new `qml.Projector` observable in
   PennyLane v0.16 to the Cirq devices.
   [(#62)](https://github.com/PennyLaneAI/pennylane-cirq/pull/62)
@@ -21,7 +24,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Theodor Isacsson, Vincent Wong
+Theodor Isacsson, Romain Moyard, Vincent Wong
 
 ---
 

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -118,7 +118,7 @@ class SimulatorDevice(CirqDevice):
         # get indices for which the state is changed to input state vector elements
         ravelled_indices = np.ravel_multi_index(unravelled_indices.T, [2] * self.num_wires)
 
-        state = np.zeros([2 ** self.num_wires], dtype=np.complex128)
+        state = np.zeros([2 ** self.num_wires], dtype=np.complex64)
         state[ravelled_indices] = state_vector
         state_vector = state.reshape([2] * self.num_wires)
 


### PR DESCRIPTION
This data type change should fix the bug appearing when building the density matrix for `QubitStateVector`.