### PR TITLE
Update requirements to point to release candidate

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/PennyLaneAI/pennylane.git
+git+https://github.com/PennyLaneAI/pennylane.git@v0.16.0-rc0
 cirq>=0.10
 numpy~=1.16

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("pennylane_cirq/_version.py") as f:
 # Requirements should be as minimal as possible.
 # Avoid pinning, and use minimum version numbers
 # only where required.
-requirements = ["pennylane @ git+https://github.com/PennyLaneAI/pennylane.git", "cirq>=0.9"]
+requirements = ["pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@v0.16.0-rc0", "cirq>=0.9"]
 
 info = {
     "name": "PennyLane-Cirq",


### PR DESCRIPTION
Update the requirement of PennyLane to point to the release candidate for now, which has a PennyLane version of 0.16.0 as opposed to 0.17.0-dev on `master`.

This is required to be able to run the demos in the QML repo, see e.g., https://github.com/PennyLaneAI/qml/pull/288.