### PR TITLE
Update `qml.QubitUnitary` error message in test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pennylane>=0.16
+git+https://github.com/PennyLaneAI/pennylane.git@master
 cirq>=0.10
 numpy~=1.16

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -281,7 +281,7 @@ class TestApplyPureState:
         dev = SimulatorDevice(2, shots=shots)
         state = np.array([[0, 123.432], [-0.432, 023.4]])
 
-        with pytest.raises(ValueError, match=r"Not a unitary matrix"):
+        with pytest.raises(ValueError, match=r"Input unitary must be of shape"):
             with mimic_execution_for_apply(dev):
                 dev.apply([qml.QubitUnitary(state, wires=[0, 1])])
 
@@ -479,7 +479,7 @@ class TestApplyMixedState:
         dev = MixedStateSimulatorDevice(2, shots=shots)
         state = np.array([[0, 123.432], [-0.432, 023.4]])
 
-        with pytest.raises(ValueError, match=r"Not a unitary matrix"):
+        with pytest.raises(ValueError, match=r"Input unitary must be of shape"):
             with mimic_execution_for_apply(dev):
                 dev.apply([qml.QubitUnitary(state, wires=[0, 1])])
 


### PR DESCRIPTION
This change was required due to an updated error message in PennyLane core from https://github.com/PennyLaneAI/pennylane/pull/1439