### PR TITLE
[WIP] Update `expval` with latest Cirq features

### DIFF
--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -207,13 +207,35 @@ class SimulatorDevice(CirqDevice):
             self.circuit.append(cirq.measure(self.qubits[wire], key=str(wire)))
 
         self._result = self._simulator.run(self.circuit, repetitions=self.shots)
-
+        print(self._result)
         # Bring measurements to a more managable form, but keep True/False as values for now
         # They will be changed in the measurement routines where the observable is available
         return np.array(
             [self._result.measurements[str(wire)].flatten() for wire in range(self.num_wires)]
         ).T.astype(int)
 
+    def expval(self, observable, shot_range=None, bin_size=None):
+
+        if self.short_name=="cirq.simulator":
+            if self.shots is None:
+                return self._simulator.simulate_expectation_values(
+                    self.circuit, cirq.PauliSum() + self.to_paulistring(observable)
+                )[0]
+            else:
+                print(self.circuit)
+                name = observable.name
+                wires = self.map_wires(observable.wires).tolist()
+                sample_slice = Ellipsis if shot_range is None else slice(*shot_range)
+
+                if isinstance(name, str) and name in {"PauliX", "PauliY", "PauliZ", "Hadamard"}:
+                    print(self._samples)
+
+            if bin_size is None:
+                return self._samples
+
+            return self._samples.reshape((bin_size, -1))
+        else:
+            return super().expval(observable, shot_range, bin_size)
 
 class MixedStateSimulatorDevice(SimulatorDevice):
     r"""Cirq mixed-state simulator device for PennyLane.

--- a/tests/test_expval.py
+++ b/tests/test_expval.py
@@ -96,7 +96,6 @@ class TestExpval:
                 dev.expval(O(wires=[1], do_queue=False)),
             ]
         )
-
         assert np.allclose(res, np.array([np.cos(theta), np.cos(theta) * np.cos(phi)]), **tol)
 
     def test_paulix_expectation(self, device, shots, tol):
@@ -315,7 +314,7 @@ class TestExpval:
         assert np.allclose(res, expected, **tol)
 
 
-@pytest.mark.parametrize("shots", [None, 8192])
+@pytest.mark.parametrize("shots", [None, 4])
 class TestTensorExpval:
     """Test tensor expectation values"""
 
@@ -472,3 +471,53 @@ class TestTensorExpval:
             np.cos(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)
         ) ** 2
         assert np.allclose(res, expected, **tol)
+
+    def test_new_expval_Z(self, device, shots, tol):
+        """Test that PauliZ expectation value is correct"""
+
+        dev = device(2)
+
+        with mimic_execution_for_expval(dev):
+            dev.apply(
+                [
+                    qml.PauliZ(wires=[0]),
+                ]
+            )
+
+        O = qml.PauliZ
+
+        dev._obs_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
+
+        res = np.array(
+            [
+                dev.expval(O(wires=[0], do_queue=False)),
+                dev.expval(O(wires=[1], do_queue=False)),
+            ]
+        )
+        print("res", res)
+
+    def test_new_expval_X(self, device, shots, tol):
+        """Test that PauliX expectation value is correct"""
+
+        dev = device(2)
+
+        O = qml.PauliX
+
+        with mimic_execution_for_expval(dev):
+            dev.apply(
+                [
+                    qml.PauliX(wires=[0]),
+                ],
+                rotations=O(wires=[0], do_queue=False).diagonalizing_gates() +
+                          O(wires=[1], do_queue=False).diagonalizing_gates(),
+            )
+
+        dev._obs_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
+
+        res = np.array(
+            [
+                dev.expval(O(wires=[0], do_queue=False)),
+                dev.expval(O(wires=[1], do_queue=False)),
+            ]
+        )
+        print("res", res)


### PR DESCRIPTION
This PR aims to update the way `expval` is evaluated, it can now use `simulate_expectation_values`from Cirq instead of the PennyLane function. It is directly related to issue https://github.com/PennyLaneAI/pennylane-cirq/issues/70.