### PR TITLE
Temporary requirement `Cirq<0.12.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,24 @@
 
 ### Breaking changes
 
+We do not support the new `Cirq` version `0.12.0` because of 
+compatibility problems with `qsim`.
+[(#74)](https://github.com/PennyLaneAI/pennylane-cirq/pull/74)
+
 ### Improvements
 
 ### Documentation
+
+Update `README.rst` file.
+[(#74)](https://github.com/PennyLaneAI/pennylane-cirq/pull/74)
 
 ### Bug fixes
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Romain Moyard
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@
 
 We do not support the new `Cirq` version `0.12.0` because of 
 compatibility problems with `qsim`.
-[(#74)](https://github.com/PennyLaneAI/pennylane-cirq/pull/74)
+[(#73)](https://github.com/PennyLaneAI/pennylane-cirq/pull/73)
 
 ### Improvements
 
 ### Documentation
 
 Update `README.rst` file.
-[(#74)](https://github.com/PennyLaneAI/pennylane-cirq/pull/74)
+[(#73)](https://github.com/PennyLaneAI/pennylane-cirq/pull/73)
 
 ### Bug fixes
 

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Features
 Installation
 ============
 
-This plugin requires Python version 3.6 or above, as well as PennyLane
+This plugin requires Python version 3.7 or above, as well as PennyLane
 and Cirq. Installation of this plugin, as well as all dependencies, can be done using ``pip``:
 
 .. code-block:: bash
@@ -76,13 +76,14 @@ Dependencies
 
 PennyLane-Cirq requires the following libraries be installed:
 
-* `Python <http://python.org/>`__ >= 3.6
+* `Python <http://python.org/>`__ >= 3.7
 
 as well as the following Python packages:
 
-* `PennyLane <http://pennylane.readthedocs.io/>`__ >= 0.9
-* `Cirq <https://cirq.readthedocs.io/>`__ >= 0.7
+* `PennyLane <http://pennylane.readthedocs.io/>`__ >= 0.16
+* `Cirq <https://cirq.readthedocs.io/>`__ >= 0.10.0, < 0.12.0
 
+At the moment we do not support Cirq 0.12.0, because of compatibility problems with qsim.
 To use the qsim and qsimh devices, the qsim-Cirq interface ``qsimcirq`` is required:
 
 * `qsimcirq <https://github.com/quantumlib/qsim/blob/master/docs/cirq_interface.md>`__

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 git+https://github.com/PennyLaneAI/pennylane.git@master
-cirq>=0.10
+cirq>=0.10,<0.12
 numpy~=1.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 git+https://github.com/PennyLaneAI/pennylane.git@master
-cirq>=0.10,<0.12
+cirq>=0.10
 numpy~=1.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 git+https://github.com/PennyLaneAI/pennylane.git@master
-cirq>=0.10,<0.11
+cirq>=0.10,<0.12
 numpy~=1.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 git+https://github.com/PennyLaneAI/pennylane.git@master
-cirq>=0.10
+cirq>=0.10,<0.11
 numpy~=1.16

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("pennylane_cirq/_version.py") as f:
 # Requirements should be as minimal as possible.
 # Avoid pinning, and use minimum version numbers
 # only where required.
-requirements = ["pennylane>=0.16", "cirq>=0.9,<0.12"]
+requirements = ["pennylane>=0.16", "cirq>=0.9"]
 
 info = {
     "name": "PennyLane-Cirq",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("pennylane_cirq/_version.py") as f:
 # Requirements should be as minimal as possible.
 # Avoid pinning, and use minimum version numbers
 # only where required.
-requirements = ["pennylane>=0.16", "cirq>=0.9,<0.12"]
+requirements = ["pennylane>=0.16", "cirq>=0.10,<0.12"]
 
 info = {
     "name": "PennyLane-Cirq",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("pennylane_cirq/_version.py") as f:
 # Requirements should be as minimal as possible.
 # Avoid pinning, and use minimum version numbers
 # only where required.
-requirements = ["pennylane>=0.16", "cirq>=0.9"]
+requirements = ["pennylane>=0.16", "cirq>=0.10"]
 
 info = {
     "name": "PennyLane-Cirq",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("pennylane_cirq/_version.py") as f:
 # Requirements should be as minimal as possible.
 # Avoid pinning, and use minimum version numbers
 # only where required.
-requirements = ["pennylane>=0.16", "cirq>=0.10,<0.12"]
+requirements = ["pennylane>=0.16", "cirq>=0.9"]
 
 info = {
     "name": "PennyLane-Cirq",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("pennylane_cirq/_version.py") as f:
 # Requirements should be as minimal as possible.
 # Avoid pinning, and use minimum version numbers
 # only where required.
-requirements = ["pennylane>=0.16", "cirq>=0.10,<12"]
+requirements = ["pennylane>=0.16", "cirq>=0.10,<0.12"]
 
 info = {
     "name": "PennyLane-Cirq",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("pennylane_cirq/_version.py") as f:
 # Requirements should be as minimal as possible.
 # Avoid pinning, and use minimum version numbers
 # only where required.
-requirements = ["pennylane>=0.16", "cirq>=0.10"]
+requirements = ["pennylane>=0.16", "cirq>=0.10,<12"]
 
 info = {
     "name": "PennyLane-Cirq",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open("pennylane_cirq/_version.py") as f:
 # Requirements should be as minimal as possible.
 # Avoid pinning, and use minimum version numbers
 # only where required.
-requirements = ["pennylane>=0.16", "cirq>=0.9"]
+requirements = ["pennylane>=0.16", "cirq>=0.9,<0.12"]
 
 info = {
     "name": "PennyLane-Cirq",

--- a/tests/test_qsim_device.py
+++ b/tests/test_qsim_device.py
@@ -47,7 +47,7 @@ class TestDeviceIntegration:
 
         assert isinstance(dev, QSimDevice)
 
-    @pytest.mark.parametrize("shots", [8192, None])
+    @pytest.mark.parametrize("shots", [8192])
     def test_one_qubit_circuit(self, shots, tol):
         """Test that devices provide correct result for a simple circuit"""
 
@@ -504,7 +504,7 @@ class TestVarEstimate:
         assert var != 1.0
 
 
-@pytest.mark.parametrize("shots", [None])
+@pytest.mark.parametrize("shots", [8192])
 class TestSample:
     """Test sampling."""
 

--- a/tests/test_qsimh_device.py
+++ b/tests/test_qsimh_device.py
@@ -37,7 +37,7 @@ class TestDeviceIntegration:
 
         assert isinstance(dev, QSimhDevice)
 
-    @pytest.mark.parametrize("shots", [8192, None])
+    @pytest.mark.parametrize("shots", [8192])
     def test_one_qubit_circuit(self, shots, tol):
         """Test that devices provide correct result for a simple circuit"""
 
@@ -383,7 +383,7 @@ class TestVarEstimate:
         assert var != 1.0
 
 
-@pytest.mark.parametrize("shots", [None])
+@pytest.mark.parametrize("shots", [8192])
 class TestSample:
     """Test sampling."""
 

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -222,6 +222,7 @@ class TestSample:
 @pytest.mark.parametrize("shots", [None])
 class TestNoShotSample:
     def test_no_shot_sample(self, device, shots, tol):
+        """Test that a device with shot=None raises an error when sampling"""
         dev = device(1)
 
         with pytest.raises(qml.QuantumFunctionError):

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -34,7 +34,7 @@ def mimic_execution_for_sample(device):
         device._samples = device.generate_samples()
 
 
-@pytest.mark.parametrize("shots", [None, 8192])
+@pytest.mark.parametrize("shots", [8192])
 class TestSample:
     """Tests for the sample return type"""
 
@@ -219,7 +219,7 @@ class TestSample:
         assert np.allclose(np.mean(s1), expected, **tol)
 
 
-@pytest.mark.parametrize("shots", [None, 8192])
+@pytest.mark.parametrize("shots", [8192])
 class TestTensorSample:
     """Test tensor expectation values"""
 

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -219,6 +219,16 @@ class TestSample:
         assert np.allclose(np.mean(s1), expected, **tol)
 
 
+@pytest.mark.parametrize("shots", [None])
+class TestNoShotSample:
+    def test_no_shot_sample(self, device, shots, tol):
+        dev = device(1)
+
+        with pytest.raises(qml.QuantumFunctionError):
+            with mimic_execution_for_sample(dev):
+                dev.apply([qml.RX(1.5708, wires=[0])])
+
+
 @pytest.mark.parametrize("shots", [8192])
 class TestTensorSample:
     """Test tensor expectation values"""

--- a/tests/test_simulator_device.py
+++ b/tests/test_simulator_device.py
@@ -825,7 +825,7 @@ class TestVarEstimate:
         assert var != 1.0
 
 
-@pytest.mark.parametrize("shots", [None])
+@pytest.mark.parametrize("shots", [8192])
 class TestSample:
     """Test sampling."""
 


### PR DESCRIPTION
We temporarily require `Cirq<0.12.0` because of broken interaction between the `cirq`0.12.0 and `qsim` 0.10.0.