### PR TITLE
[OpRefactor] Fix inverses

### DIFF
--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -117,7 +117,7 @@ class CirqDevice(QubitDevice, abc.ABC):
             inverted_operation = CirqOperation(value.parametrization)
             inverted_operation.inv()
 
-            self._inverse_operation_map[key + Operation.string_for_inverse] = inverted_operation
+            self._inverse_operation_map[key + ".inv"] = inverted_operation
 
         self._complete_operation_map = {
             **self._operation_map,

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -41,7 +41,7 @@ import cirq
 import numpy as np
 import pennylane as qml
 from pennylane import QubitDevice
-from pennylane.operation import Operation, Tensor
+from pennylane.operation import Tensor
 from pennylane.wires import Wires
 
 from ._version import __version__
@@ -89,9 +89,7 @@ class CirqDevice(QubitDevice, abc.ABC):
         if qubits:
             if num_wires != len(qubits):
                 raise qml.DeviceError(
-                    "The number of given qubits and the specified number of wires have to match. Got {} wires and {} qubits.".format(
-                        wires, len(qubits)
-                    )
+                    f"The number of given qubits and the specified number of wires have to match. Got {wires} wires and {len(qubits)} qubits."
                 )
         else:
             qubits = [cirq.LineQubit(idx) for idx in range(num_wires)]
@@ -250,9 +248,7 @@ class CirqDevice(QubitDevice, abc.ABC):
         for i, operation in enumerate(operations):
             if i > 0 and operation.name in {"BasisState", "QubitStateVector"}:
                 raise qml.DeviceError(
-                    "The operation {} is only supported at the beginning of a circuit.".format(
-                        operation.name
-                    )
+                    f"The operation {operation.name} is only supported at the beginning of a circuit."
                 )
 
             if operation.name == "BasisState":


### PR DESCRIPTION
The operator refactor in PennyLane removed an obsolete legacy attribute `string_for_inverse`, which was set to `".inv"` everywhere and only used in one place in the core code.

However, the cirq device uses it in one place. Replacing it with `".inv"` should make the device compatible with the refactor, and have no downsides. While this is not urgent for the upcoming release, it would be easy to merge it in asap.

**Changes** 

Replace attribute call with fixed string.

Three minor improvements to pacify codefactor on unrelated issues, which are picked up in the latest version of the standard.