### PR TITLE
Bug when trying to generate_samples() repeatedly

### DIFF
--- a/pennylane_cirq/qsim_device.py
+++ b/pennylane_cirq/qsim_device.py
@@ -165,7 +165,7 @@ class QSimhDevice(SimulatorDevice):
 
     def generate_samples(self):
         # pylint: disable=missing-function-docstring
-        number_of_states = 2 ** self.num_wires
+        number_of_states = 2**self.num_wires
 
         rotated_prob = self.analytic_probability()
         if rotated_prob is not None:

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -118,7 +118,7 @@ class SimulatorDevice(CirqDevice):
         # get indices for which the state is changed to input state vector elements
         ravelled_indices = np.ravel_multi_index(unravelled_indices.T, [2] * self.num_wires)
 
-        state = np.zeros([2 ** self.num_wires], dtype=np.complex64)
+        state = np.zeros([2**self.num_wires], dtype=np.complex64)
         state[ravelled_indices] = state_vector
         state_vector = state.reshape([2] * self.num_wires)
 
@@ -317,7 +317,7 @@ class MixedStateSimulatorDevice(SimulatorDevice):
 
     def _convert_to_density_matrix(self, state_vec):
         """Convert ``state_vec`` into a density matrix."""
-        dim = 2 ** self.num_wires
+        dim = 2**self.num_wires
         return np.kron(state_vec, state_vec.conj()).reshape((dim, dim))
 
     @staticmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,7 +87,7 @@ def init_state(scope="session"):
     """Fixture to create an n-qubit initial state"""
 
     def _init_state(n):
-        state = np.random.random([2 ** n]) + np.random.random([2 ** n]) * 1j
+        state = np.random.random([2**n]) + np.random.random([2**n]) * 1j
         state /= np.linalg.norm(state)
         return state
 

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -101,7 +101,7 @@ class TestApplyPureState:
 
         res = dev._state
 
-        expected = np.zeros([2 ** 4])
+        expected = np.zeros([2**4])
         expected[np.ravel_multi_index(state, [2] * 4)] = 1
         assert np.allclose(res, expected, **tol)
 
@@ -142,7 +142,7 @@ class TestApplyPureState:
 
         res = dev._state
 
-        expected = np.zeros([2 ** 4])
+        expected = np.zeros([2**4])
         expected[np.ravel_multi_index(state, [2] * 4)] = 1
         assert np.allclose(res, expected, **tol)
 
@@ -340,7 +340,7 @@ class TestApplyMixedState:
 
         expected = np.zeros([16])
         expected[np.ravel_multi_index(state, [2] * 4)] = 1
-        expected = np.kron(expected, expected.conj()).reshape([2 ** 4, 2 ** 4])
+        expected = np.kron(expected, expected.conj()).reshape([2**4, 2**4])
         assert np.allclose(res, expected, **tol)
 
     def test_identity_basis_state(self, shots, tol):
@@ -475,7 +475,7 @@ class TestApplyMixedState:
 
         res = dev._state
         expected = mat @ state
-        expected = np.kron(expected, expected.conj()).reshape([2 ** N, 2 ** N])
+        expected = np.kron(expected, expected.conj()).reshape([2**N, 2**N])
         assert np.allclose(res, expected, **tol)
 
     def test_invalid_qubit_state_unitary(self, shots):

--- a/tests/test_cirq_device.py
+++ b/tests/test_cirq_device.py
@@ -116,7 +116,7 @@ class TestCirqDeviceIntegration:
 
     def test_outer_init_of_qubits_with_wire_label_strings(self):
         """Tests that giving qubits as parameters to CirqDevice works when the user also
-         provides custom string wire labels."""
+        provides custom string wire labels."""
 
         unordered_qubits = [
             cirq.GridQubit(0, 1),
@@ -137,7 +137,7 @@ class TestCirqDeviceIntegration:
 
     def test_outer_init_of_qubits_with_wire_label_ints(self):
         """Tests that giving qubits as parameters to CirqDevice works when the user also provides
-         custom integer wire labels."""
+        custom integer wire labels."""
 
         unordered_qubits = [
             cirq.GridQubit(0, 1),
@@ -215,13 +215,13 @@ class TestOperations:
             (qml.PauliX(wires=[0]), [cirq.X]),
             (qml.PauliY(wires=[0]), [cirq.Y]),
             (qml.PauliZ(wires=[0]), [cirq.Z]),
-            (qml.PauliX(wires=[0]).inv(), [cirq.X ** -1]),
-            (qml.PauliY(wires=[0]).inv(), [cirq.Y ** -1]),
-            (qml.PauliZ(wires=[0]).inv(), [cirq.Z ** -1]),
+            (qml.PauliX(wires=[0]).inv(), [cirq.X**-1]),
+            (qml.PauliY(wires=[0]).inv(), [cirq.Y**-1]),
+            (qml.PauliZ(wires=[0]).inv(), [cirq.Z**-1]),
             (qml.Hadamard(wires=[0]), [cirq.H]),
-            (qml.Hadamard(wires=[0]).inv(), [cirq.H ** -1]),
+            (qml.Hadamard(wires=[0]).inv(), [cirq.H**-1]),
             (qml.S(wires=[0]), [cirq.S]),
-            (qml.S(wires=[0]).inv(), [cirq.S ** -1]),
+            (qml.S(wires=[0]).inv(), [cirq.S**-1]),
             (qml.PhaseShift(1.4, wires=[0]), [cirq.ZPowGate(exponent=1.4 / np.pi)]),
             (qml.PhaseShift(-1.2, wires=[0]), [cirq.ZPowGate(exponent=-1.2 / np.pi)]),
             (qml.PhaseShift(2, wires=[0]), [cirq.ZPowGate(exponent=2 / np.pi)]),
@@ -317,11 +317,11 @@ class TestOperations:
         "gate,expected_cirq_gates",
         [
             (qml.CNOT(wires=[0, 1]), [cirq.CNOT]),
-            (qml.CNOT(wires=[0, 1]).inv(), [cirq.CNOT ** -1]),
+            (qml.CNOT(wires=[0, 1]).inv(), [cirq.CNOT**-1]),
             (qml.SWAP(wires=[0, 1]), [cirq.SWAP]),
-            (qml.SWAP(wires=[0, 1]).inv(), [cirq.SWAP ** -1]),
+            (qml.SWAP(wires=[0, 1]).inv(), [cirq.SWAP**-1]),
             (qml.CZ(wires=[0, 1]), [cirq.CZ]),
-            (qml.CZ(wires=[0, 1]).inv(), [cirq.CZ ** -1]),
+            (qml.CZ(wires=[0, 1]).inv(), [cirq.CZ**-1]),
             (qml.CRX(1.4, wires=[0, 1]), [cirq.ControlledGate(cirq.rx(1.4))]),
             (qml.CRX(-1.2, wires=[0, 1]), [cirq.ControlledGate(cirq.rx(-1.2))]),
             (qml.CRX(2, wires=[0, 1]), [cirq.ControlledGate(cirq.rx(2))]),

--- a/tests/test_cirq_operation.py
+++ b/tests/test_cirq_operation.py
@@ -113,10 +113,10 @@ class TestCirqOperation:
         gate_applications = list(operation.apply(qubit))
 
         assert gate_applications[0] == cirq.rz(-0.3).on(qubit)
-        assert gate_applications[1] == (cirq.Z ** -1).on(qubit)
+        assert gate_applications[1] == (cirq.Z**-1).on(qubit)
         assert gate_applications[2] == cirq.rx(-0.2).on(qubit)
         assert gate_applications[3] == cirq.ry(-0.1).on(qubit)
-        assert gate_applications[4] == (cirq.X ** -1).on(qubit)
+        assert gate_applications[4] == (cirq.X**-1).on(qubit)
 
     def test_inv_error(self):
         """Test that inv raises an error if the CirqOperation was already parametrized."""

--- a/tests/test_expval.py
+++ b/tests/test_expval.py
@@ -148,15 +148,12 @@ class TestExpval:
             return qml.expval(qml.Hadamard(wires=[1]))
 
         res = [circuit0(phi, theta), circuit1(phi, theta)]
-        expected = (
-            np.array(
-                [
-                    np.sin(theta) * np.sin(phi) + np.cos(theta),
-                    np.cos(theta) * np.cos(phi) + np.sin(phi),
-                ]
-            )
-            / np.sqrt(2)
-        )
+        expected = np.array(
+            [
+                np.sin(theta) * np.sin(phi) + np.cos(theta),
+                np.cos(theta) * np.cos(phi) + np.sin(phi),
+            ]
+        ) / np.sqrt(2)
         assert np.allclose(res, expected, **tol)
 
     def test_hermitian_expectation(self, device, shots, tol):

--- a/tests/test_mixed_simulator_device.py
+++ b/tests/test_mixed_simulator_device.py
@@ -746,6 +746,7 @@ class TestExpval:
         qnode = qml.QNode(circuit, dev)
         assert np.allclose(qnode(), 0.0)
 
+
 @pytest.mark.parametrize("shots", [None])
 class TestVar:
     """Tests that variances are properly calculated."""
@@ -937,7 +938,7 @@ class TestSample:
 
         # s1 should only contain 1 and -1, which is guaranteed if
         # they square to 1
-        assert np.allclose(s1 ** 2, 1, **tol)
+        assert np.allclose(s1**2, 1, **tol)
 
 
 class TestState:

--- a/tests/test_qsim_device.py
+++ b/tests/test_qsim_device.py
@@ -567,10 +567,17 @@ class TestSample:
         qsim_device_2_wires.reset()
         qsim_device_2_wires.apply([qml.RX(1.5708, wires=[0]), qml.RX(1.5708, wires=[1])])
 
+        print(qsim_device_2_wires.circuit)
+
         qsim_device_2_wires.shots = 10
         qsim_device_2_wires._samples = qsim_device_2_wires.generate_samples()
         s1 = qsim_device_2_wires.sample(qml.PauliZ(0))
         assert np.array_equal(s1.shape, (10,))
+
+        print(qsim_device_2_wires.circuit)
+        # qsim_device_2_wires.reset()
+        # qsim_device_2_wires.apply([qml.RX(1.5708, wires=[0]), qml.RX(1.5708, wires=[1])])
+        # print(qsim_device_2_wires.circuit)
 
         qsim_device_2_wires.shots = 12
         qsim_device_2_wires._samples = qsim_device_2_wires.generate_samples()

--- a/tests/test_qsim_device.py
+++ b/tests/test_qsim_device.py
@@ -383,9 +383,7 @@ class TestExpval:
             (qml.Identity, 1),
         ],
     )
-    def test_expval_identity(
-            self, qsim_device_2_wires, tol, observable1, expected_output
-    ):
+    def test_expval_identity(self, qsim_device_2_wires, tol, observable1, expected_output):
         """Tests that expectation values are properly calculated for single-wire identity."""
 
         obs = observable1(wires=[0])
@@ -405,7 +403,7 @@ class TestExpval:
         ],
     )
     def test_expval_multiple_wire_identity(
-            self, qsim_device_2_wires, tol, observable1, observable2, expected_output
+        self, qsim_device_2_wires, tol, observable1, observable2, expected_output
     ):
         """Tests that expectation values are properly calculated for multi-wire observables identity."""
 
@@ -560,7 +558,14 @@ class TestVarEstimate:
 class TestSample:
     """Test sampling."""
 
-    @pytest.mark.parametrize("custom_shots, obs", [(10, qml.PauliZ(0)), (12, qml.PauliZ(1)), (17, qml.Hermitian(np.diag([1, 1, 1, -1]), wires=[0, 1]))])
+    @pytest.mark.parametrize(
+        "custom_shots, obs",
+        [
+            (10, qml.PauliZ(0)),
+            (12, qml.PauliZ(1)),
+            (17, qml.Hermitian(np.diag([1, 1, 1, -1]), wires=[0, 1])),
+        ],
+    )
     def test_sample_dimensions(self, qsim_device_2_wires, custom_shots, obs):
         """Tests if the samples returned by the sample function have
         the correct dimensions
@@ -587,7 +592,7 @@ class TestSample:
 
         # s1 should only contain 1 and -1, which is guaranteed if
         # they square to 1
-        assert np.allclose(s1 ** 2, 1, **tol)
+        assert np.allclose(s1**2, 1, **tol)
 
 
 class TestState:

--- a/tests/test_qsim_device.py
+++ b/tests/test_qsim_device.py
@@ -560,39 +560,18 @@ class TestVarEstimate:
 class TestSample:
     """Test sampling."""
 
-    def test_sample_dimensions(self, qsim_device_2_wires):
+    @pytest.mark.parametrize("custom_shots, obs", [(10, qml.PauliZ(0)), (12, qml.PauliZ(1)), (17, qml.Hermitian(np.diag([1, 1, 1, -1]), wires=[0, 1]))])
+    def test_sample_dimensions(self, qsim_device_2_wires, custom_shots, obs):
         """Tests if the samples returned by the sample function have
         the correct dimensions
         """
         qsim_device_2_wires.reset()
         qsim_device_2_wires.apply([qml.RX(1.5708, wires=[0]), qml.RX(1.5708, wires=[1])])
 
-        print(qsim_device_2_wires.circuit)
-
-        qsim_device_2_wires.shots = 10
+        qsim_device_2_wires.shots = custom_shots
         qsim_device_2_wires._samples = qsim_device_2_wires.generate_samples()
-        s1 = qsim_device_2_wires.sample(qml.PauliZ(0))
-        assert np.array_equal(s1.shape, (10,))
-
-        print(f"\n{qsim_device_2_wires.circuit}")
-        qsim_device_2_wires.reset()
-        qsim_device_2_wires.apply([qml.RX(1.5708, wires=[0]), qml.RX(1.5708, wires=[1])])
-        print(f"\n{qsim_device_2_wires.circuit}")
-
-        qsim_device_2_wires.shots = 12
-        qsim_device_2_wires._samples = qsim_device_2_wires.generate_samples()
-        s2 = qsim_device_2_wires.sample(qml.PauliZ(1))
-        assert np.array_equal(s2.shape, (12,))
-
-        print(f"\n{qsim_device_2_wires.circuit}")
-        qsim_device_2_wires.reset()
-        qsim_device_2_wires.apply([qml.RX(1.5708, wires=[0]), qml.RX(1.5708, wires=[1])])
-        print(f"\n{qsim_device_2_wires.circuit}")
-        
-        qsim_device_2_wires.shots = 17
-        qsim_device_2_wires._samples = qsim_device_2_wires.generate_samples()
-        s3 = qsim_device_2_wires.sample(qml.Hermitian(np.diag([1, 1, 1, -1]), wires=[0, 1]))
-        assert np.array_equal(s3.shape, (17,))
+        s1 = qsim_device_2_wires.sample(obs)
+        assert np.array_equal(s1.shape, (custom_shots,))
 
     def test_sample_values(self, qsim_device_2_wires, tol):
         """Tests if the samples returned by sample have

--- a/tests/test_qsim_device.py
+++ b/tests/test_qsim_device.py
@@ -574,16 +574,21 @@ class TestSample:
         s1 = qsim_device_2_wires.sample(qml.PauliZ(0))
         assert np.array_equal(s1.shape, (10,))
 
-        print(qsim_device_2_wires.circuit)
-        # qsim_device_2_wires.reset()
-        # qsim_device_2_wires.apply([qml.RX(1.5708, wires=[0]), qml.RX(1.5708, wires=[1])])
-        # print(qsim_device_2_wires.circuit)
+        print(f"\n{qsim_device_2_wires.circuit}")
+        qsim_device_2_wires.reset()
+        qsim_device_2_wires.apply([qml.RX(1.5708, wires=[0]), qml.RX(1.5708, wires=[1])])
+        print(f"\n{qsim_device_2_wires.circuit}")
 
         qsim_device_2_wires.shots = 12
         qsim_device_2_wires._samples = qsim_device_2_wires.generate_samples()
         s2 = qsim_device_2_wires.sample(qml.PauliZ(1))
         assert np.array_equal(s2.shape, (12,))
 
+        print(f"\n{qsim_device_2_wires.circuit}")
+        qsim_device_2_wires.reset()
+        qsim_device_2_wires.apply([qml.RX(1.5708, wires=[0]), qml.RX(1.5708, wires=[1])])
+        print(f"\n{qsim_device_2_wires.circuit}")
+        
         qsim_device_2_wires.shots = 17
         qsim_device_2_wires._samples = qsim_device_2_wires.generate_samples()
         s3 = qsim_device_2_wires.sample(qml.Hermitian(np.diag([1, 1, 1, -1]), wires=[0, 1]))

--- a/tests/test_qsimh_device.py
+++ b/tests/test_qsimh_device.py
@@ -434,7 +434,7 @@ class TestSample:
 
         # s1 should only contain 1 and -1, which is guaranteed if
         # they square to 1
-        assert np.allclose(s1 ** 2, 1, **tol)
+        assert np.allclose(s1**2, 1, **tol)
 
 
 class TestState:

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -58,7 +58,7 @@ class TestSample:
         s1 = dev.sample(qml.PauliZ(wires=[0]))
 
         # s1 should only contain 1 and -1
-        assert np.allclose(s1 ** 2, 1, **tol)
+        assert np.allclose(s1**2, 1, **tol)
 
     def test_sample_values_hermitian(self, device, shots, tol):
         """Tests if the samples of a Hermitian observable returned by sample have
@@ -258,7 +258,7 @@ class TestTensorSample:
         s1 = dev.sample(obs)
 
         # s1 should only contain 1 and -1
-        assert np.allclose(s1 ** 2, 1, **tol)
+        assert np.allclose(s1**2, 1, **tol)
 
         mean = np.mean(s1)
         expected = np.sin(theta) * np.sin(phi) * np.sin(varphi)
@@ -304,7 +304,7 @@ class TestTensorSample:
         s1 = dev.sample(obs)
 
         # s1 should only contain 1 and -1
-        assert np.allclose(s1 ** 2, 1, **tol)
+        assert np.allclose(s1**2, 1, **tol)
 
         mean = np.mean(s1)
         expected = -(np.cos(varphi) * np.sin(phi) + np.sin(varphi) * np.cos(theta)) / np.sqrt(2)

--- a/tests/test_simulator_device.py
+++ b/tests/test_simulator_device.py
@@ -932,7 +932,7 @@ class TestSample:
 
         # s1 should only contain 1 and -1, which is guaranteed if
         # they square to 1
-        assert np.allclose(s1 ** 2, 1, **tol)
+        assert np.allclose(s1**2, 1, **tol)
 
 
 class TestState:


### PR DESCRIPTION
The bug was in the test `test_qsim_device.py:TestSample:test_sample_dimensions`. When `qsim_device.generate_sampels()` is called, it augments the circuit in order to make the measurements. The bug was introduced when this method is called repeatedly without performing a reset `qsim_device.reset()` between calls. 