### PR TITLE
Get cirq-core only

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pennylane>=0.17
-cirq>=0.10
+cirq-core>=0.10
 cirq-pasqal>=0.10
 numpy~=1.16

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open("pennylane_cirq/_version.py") as f:
 # Avoid pinning, and use minimum version numbers
 # only where required.
 
-requirements = ["pennylane>=0.17", "cirq>=0.10", "cirq-pasqal>=0.10"]
+requirements = ["pennylane>=0.17", "cirq-core>=0.10", "cirq-pasqal>=0.10"]
 
 info = {
     "name": "PennyLane-Cirq",


### PR DESCRIPTION
Installing `cirq` pulls in packages that are not used by this plugin, but packages that bring further dependency constraints.

Pulling `cirq-core` only along with `cirq-pasqal` should provide a solution.

This is useful for the QML repository, where a dependency conflict arises between `cirq-rigetti` and TensorFlow:
```
The conflict is caused by:
    tensorflow 2.6.0 depends on six~=1.15.0
    cirq-rigetti 0.13.1 depends on six~=1.16.0
```
With the changes here, we'll no longer be requiring `cirq-rigetti`.