### PR TITLE
Cirq changed `initial_state` kwarg to be density matrix

### DIFF
--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -118,7 +118,7 @@ class SimulatorDevice(CirqDevice):
         # get indices for which the state is changed to input state vector elements
         ravelled_indices = np.ravel_multi_index(unravelled_indices.T, [2] * self.num_wires)
 
-        state = np.zeros([2 ** self.num_wires], dtype=np.complex64)
+        state = np.zeros([2**self.num_wires], dtype=np.complex64)
         state[ravelled_indices] = state_vector
         state_vector = state.reshape([2] * self.num_wires)
 
@@ -173,7 +173,7 @@ class SimulatorDevice(CirqDevice):
                 isinstance(self._simulator, cirq.DensityMatrixSimulator)
                 and self._initial_state is not None
             ):
-                if np.shape(self._initial_state) == (2 ** self.num_wires,):
+                if np.shape(self._initial_state) == (2**self.num_wires,):
                     self._initial_state = self._convert_to_density_matrix(self._initial_state)
 
             self._result = self._simulator.simulate(self.circuit, initial_state=self._initial_state)
@@ -189,7 +189,7 @@ class SimulatorDevice(CirqDevice):
 
     def _convert_to_density_matrix(self, state_vec):
         """Convert ``state_vec`` into a density matrix."""
-        dim = 2 ** self.num_wires
+        dim = 2**self.num_wires
         return np.kron(state_vec, state_vec.conj()).reshape((dim, dim))
 
     @staticmethod

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -169,8 +169,12 @@ class SimulatorDevice(CirqDevice):
             self.circuit.append(cirq.IdentityGate(1)(q))
 
         if self.shots is None:
+            self._initial_state = self.refresh_initial_state()
             self._result = self._simulator.simulate(self.circuit, initial_state=self._initial_state)
             self._state = self._get_state_from_cirq(self._result)
+
+    def refresh_initial_state(self):
+        return self._initial_state
 
     def analytic_probability(self, wires=None):
         # pylint: disable=missing-function-docstring
@@ -319,6 +323,13 @@ class MixedStateSimulatorDevice(SimulatorDevice):
         """Convert ``state_vec`` into a density matrix."""
         dim = 2**self.num_wires
         return np.kron(state_vec, state_vec.conj()).reshape((dim, dim))
+
+    def refresh_initial_state(self):
+        if self._initial_state is not None:
+            if np.shape(self._initial_state) == (2**self.num_wires,):
+                return self._convert_to_density_matrix(self._initial_state)
+            else:
+                return self._initial_state
 
     @staticmethod
     def _get_state_from_cirq(result):

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -169,13 +169,6 @@ class SimulatorDevice(CirqDevice):
             self.circuit.append(cirq.IdentityGate(1)(q))
 
         if self.shots is None:
-            if (
-                isinstance(self._simulator, cirq.DensityMatrixSimulator)
-                and self._initial_state is not None
-            ):
-                if np.shape(self._initial_state) == (2**self.num_wires,):
-                    self._initial_state = self._convert_to_density_matrix(self._initial_state)
-
             self._result = self._simulator.simulate(self.circuit, initial_state=self._initial_state)
             self._state = self._get_state_from_cirq(self._result)
 
@@ -186,11 +179,6 @@ class SimulatorDevice(CirqDevice):
 
         probs = self._get_computational_basis_probs()
         return self.marginal_prob(probs, wires)
-
-    def _convert_to_density_matrix(self, state_vec):
-        """Convert ``state_vec`` into a density matrix."""
-        dim = 2**self.num_wires
-        return np.kron(state_vec, state_vec.conj()).reshape((dim, dim))
 
     @staticmethod
     def _get_state_from_cirq(result):
@@ -326,6 +314,11 @@ class MixedStateSimulatorDevice(SimulatorDevice):
     def _apply_qubit_state_vector(self, qubit_state_vector_operation):
         super()._apply_qubit_state_vector(qubit_state_vector_operation)
         self._initial_state = self._convert_to_density_matrix(self._initial_state)
+
+    def _convert_to_density_matrix(self, state_vec):
+        """Convert ``state_vec`` into a density matrix."""
+        dim = 2**self.num_wires
+        return np.kron(state_vec, state_vec.conj()).reshape((dim, dim))
 
     @staticmethod
     def _get_state_from_cirq(result):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pennylane>=0.23
+git+https://github.com/PennyLaneAI/pennylane@master#egg=pennylane
 cirq-core>=0.10
 cirq-pasqal>=0.10
 numpy~=1.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pennylane>=0.17
+pennylane>=0.23
 cirq-core>=0.10
 cirq-pasqal>=0.10
 numpy~=1.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/PennyLaneAI/pennylane@master#egg=pennylane
+pennylane>=0.17
 cirq-core>=0.10
 cirq-pasqal>=0.10
 numpy~=1.16

--- a/tests/test_mixed_simulator_device.py
+++ b/tests/test_mixed_simulator_device.py
@@ -92,7 +92,8 @@ class TestApply:
         operations that have no parameters."""
 
         simulator_device_1_wire.reset()
-        simulator_device_1_wire._initial_state = np.array(input, dtype=np.complex64)
+        init_state = np.array(input, dtype=np.complex64)
+        simulator_device_1_wire._initial_state = simulator_device_1_wire._convert_to_density_matrix(init_state)
         simulator_device_1_wire.apply([op(wires=[0])])
 
         state = np.array(expected_pure_state)
@@ -133,7 +134,8 @@ class TestApply:
         operations that have no parameters."""
 
         simulator_device_2_wires.reset()
-        simulator_device_2_wires._initial_state = np.array(input, dtype=np.complex64)
+        init_state = np.array(input, dtype=np.complex64)
+        simulator_device_2_wires._initial_state = simulator_device_2_wires._convert_to_density_matrix(init_state)
         simulator_device_2_wires.apply([op(wires=[0, 1])])
 
         state = np.array(expected_pure_state)
@@ -284,7 +286,8 @@ class TestApply:
         operations that have no parameters."""
 
         simulator_device_1_wire.reset()
-        simulator_device_1_wire._initial_state = np.array(input, dtype=np.complex64)
+        init_state = np.array(input, dtype=np.complex64)
+        simulator_device_1_wire._initial_state = simulator_device_1_wire._convert_to_density_matrix(init_state)
         simulator_device_1_wire.apply([op(*par, wires=[0])])
 
         state = np.array(expected_pure_state)
@@ -413,7 +416,8 @@ class TestApply:
         operations that have no parameters."""
 
         simulator_device_2_wires.reset()
-        simulator_device_2_wires._initial_state = np.array(input, dtype=np.complex64)
+        init_state = np.array(input, dtype=np.complex64)
+        simulator_device_2_wires._initial_state = simulator_device_2_wires._convert_to_density_matrix(init_state)
         simulator_device_2_wires.apply([op(*par, wires=[0, 1])])
 
         state = np.array(expected_pure_state)

--- a/tests/test_native_ops.py
+++ b/tests/test_native_ops.py
@@ -53,7 +53,8 @@ class TestApply:
         """Tests that applying a depolarizing operation yields the expected output state for single wire."""
 
         simulator_device_1_wire.reset()
-        simulator_device_1_wire._initial_state = np.array(input, dtype=np.complex64)
+        init_state = np.array(input, dtype=np.complex64)
+        simulator_device_1_wire._initial_state = simulator_device_1_wire._convert_to_density_matrix(init_state)
         simulator_device_1_wire.apply([ops.Depolarize(*par, wires=[0])])
 
         assert np.allclose(simulator_device_1_wire.state, expected_density_matrix, **tol)
@@ -81,7 +82,8 @@ class TestApply:
         """Tests that applying a bit flip operation yields the expected output state for single wire."""
 
         simulator_device_1_wire.reset()
-        simulator_device_1_wire._initial_state = np.array(input, dtype=np.complex64)
+        init_state = np.array(input, dtype=np.complex64)
+        simulator_device_1_wire._initial_state = simulator_device_1_wire._convert_to_density_matrix(init_state)
         simulator_device_1_wire.apply([ops.BitFlip(*par, wires=[0])])
 
         assert np.allclose(simulator_device_1_wire.state, expected_density_matrix, **tol)
@@ -109,7 +111,8 @@ class TestApply:
         """Tests that applying a phase flip operation yields the expected output state for single wire."""
 
         simulator_device_1_wire.reset()
-        simulator_device_1_wire._initial_state = np.array(input, dtype=np.complex64)
+        init_state = np.array(input, dtype=np.complex64)
+        simulator_device_1_wire._initial_state = simulator_device_1_wire._convert_to_density_matrix(init_state)
         simulator_device_1_wire.apply([ops.PhaseFlip(*par, wires=[0])])
 
         assert np.allclose(simulator_device_1_wire.state, expected_density_matrix, **tol)
@@ -145,7 +148,8 @@ class TestApply:
         """Tests that applying a phase damping operation yields the expected output state for single wire."""
 
         simulator_device_1_wire.reset()
-        simulator_device_1_wire._initial_state = np.array(input, dtype=np.complex64)
+        init_state = np.array(input, dtype=np.complex64)
+        simulator_device_1_wire._initial_state = simulator_device_1_wire._convert_to_density_matrix(init_state)
         simulator_device_1_wire.apply([ops.PhaseDamp(*par, wires=[0])])
 
         assert np.allclose(simulator_device_1_wire.state, expected_density_matrix, **tol)
@@ -181,7 +185,8 @@ class TestApply:
         """Tests that applying an amplitude damping operation yields the expected output state for single wire."""
 
         simulator_device_1_wire.reset()
-        simulator_device_1_wire._initial_state = np.array(input, dtype=np.complex64)
+        init_state = np.array(input, dtype=np.complex64)
+        simulator_device_1_wire._initial_state = simulator_device_1_wire._convert_to_density_matrix(init_state)
         simulator_device_1_wire.apply([ops.AmplitudeDamp(*par, wires=[0])])
 
         assert np.allclose(simulator_device_1_wire.state, expected_density_matrix, **tol)


### PR DESCRIPTION
When calling the `simulator.simulate(circuit)` method for `cirq.DensityMatrixSimulator()` simulator (and all mixed state simulators I assume), the kwarg `initial_state=None` was previously passed as a state vector. Now it is required that this quantity be passed as a density matrix. 

The unit tests were updated to make use of this functionality. No other changes required  