### PR TITLE
Remove Python 3.7, add Python 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10']
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, '3.10', '3.11']
 
     steps:
       - name: Cancel Previous Runs
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
 
       - name: Build and install Plugin
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ### New features since last release
 
+* Adds support for Python 3.10.
+  [(#123)](https://github.com/PennyLaneAI/pennylane-cirq/pull/123)
+
 ### Breaking changes
+
+* Removes support for Python 3.7.
+  [(#123)](https://github.com/PennyLaneAI/pennylane-cirq/pull/123)
 
 ### Improvements
 
@@ -13,6 +19,8 @@
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Christina Lee
 
 ---
 # Release 0.27.0

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Features
 Installation
 ============
 
-This plugin requires Python version 3.7 or above, as well as PennyLane
+This plugin requires Python version 3.8 or above, as well as PennyLane
 and Cirq. Installation of this plugin, as well as all dependencies, can be done using ``pip``:
 
 .. code-block:: bash
@@ -76,7 +76,7 @@ Dependencies
 
 PennyLane-Cirq requires the following libraries be installed:
 
-* `Python <http://python.org/>`__ >= 3.7
+* `Python <http://python.org/>`__ >= 3.8
 
 as well as the following Python packages:
 

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering :: Physics",
 ]

--- a/setup.py
+++ b/setup.py
@@ -62,9 +62,10 @@ classifiers = [
     "Programming Language :: Python",
     # Make sure to specify here the versions of Python supported
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering :: Physics",
 ]


### PR DESCRIPTION
This PR adds Python 3.10 tests and removes Python 3.7.  Python 3.11 is not yet added as `qsimcirq` does not yet support Python 3.11.