### PR TITLE
add PR link to changelog; require PL master

### DIFF
--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -26,5 +26,5 @@ jobs:
           title: Version Bump
           body: updated changelog and _version.py
           branch: post-release-version-bump
-          reviewers: Jaybsoni
+          reviewers: timmysilv
           base: master

--- a/.github/workflows/pre_release_version_bump.yml
+++ b/.github/workflows/pre_release_version_bump.yml
@@ -25,5 +25,5 @@ jobs:
           title: Version Bump
           body: updated changelog and _version.py
           branch: pre-release-version-bump
-          reviewers: Jaybsoni
+          reviewers: timmysilv
           base: master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@
 ### New features since last release
 
 * Support for adjoint operators has been added.
+  [(#130)](https://github.com/PennyLaneAI/pennylane-cirq/pull/130)
 
 ### Breaking changes
 
 * Support for inverse operators has been removed.
   Note that the `inv()` method and `inverse` property are removed from PennyLane operators as of PennyLane 0.29.
+  [(#130)](https://github.com/PennyLaneAI/pennylane-cirq/pull/130)
 
 ### Contributors
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ openfermion==1.1.0
 openfermionpyscf==0.5
 packaging==21.0
 pandas==1.3.3
-pennylane==0.29.0
+git+https://github.com/PennyLaneAI/pennylane.git@master
 PennyLane-Lightning==0.22.1
 Pillow==9.1.1
 pluggy==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ openfermion==1.1.0
 openfermionpyscf==0.5
 packaging==21.0
 pandas==1.3.3
-pennylane==0.23.0
+pennylane==0.29.0
 PennyLane-Lightning==0.22.1
 Pillow==9.1.1
 pluggy==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open("pennylane_cirq/_version.py") as f:
 # Avoid pinning, and use minimum version numbers
 # only where required.
 
-requirements = ["pennylane>=0.29", "cirq-core>=0.10", "cirq-pasqal>=0.10"]
+requirements = ["pennylane @ git+https://github.com/PennyLaneAI/pennylane.git", "cirq-core>=0.10", "cirq-pasqal>=0.10"]
 
 info = {
     "name": "PennyLane-Cirq",

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open("pennylane_cirq/_version.py") as f:
 # Avoid pinning, and use minimum version numbers
 # only where required.
 
-requirements = ["pennylane>=0.17", "cirq-core>=0.10", "cirq-pasqal>=0.10"]
+requirements = ["pennylane>=0.29", "cirq-core>=0.10", "cirq-pasqal>=0.10"]
 
 info = {
     "name": "PennyLane-Cirq",


### PR DESCRIPTION
fixing the changelog and requiring PL master. This is necessary because this release of pennylane_cirq uses `StatePrep.state_vector` which will be introduced in 0.29.