### PR TITLE
manual pre-release 0.29 updates

### DIFF
--- a/pennylane_cirq/_version.py
+++ b/pennylane_cirq/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.28.0"
+__version__ = "0.29.0"


### PR DESCRIPTION
just realized post-release was missed after 0.28, despite me manually making the changelog update in a previous PR! anyway - this is all that is missing for 0.29 to be release-ready now.

example of previous pre-release: #128 
changelog for this release added in #130 (first commit there)