### PR TITLE
pin versions to 0.29 rc branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ openfermion==1.1.0
 openfermionpyscf==0.5
 packaging==21.0
 pandas==1.3.3
-git+https://github.com/PennyLaneAI/pennylane.git@master
+git+https://github.com/PennyLaneAI/pennylane.git@v0.29.0-rc0
 PennyLane-Lightning==0.22.1
 Pillow==9.1.1
 pluggy==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open("pennylane_cirq/_version.py") as f:
 # Avoid pinning, and use minimum version numbers
 # only where required.
 
-requirements = ["pennylane @ git+https://github.com/PennyLaneAI/pennylane.git", "cirq-core>=0.10", "cirq-pasqal>=0.10"]
+requirements = ["pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@v0.29.0-rc0", "cirq-core>=0.10", "cirq-pasqal>=0.10"]
 
 info = {
     "name": "PennyLane-Cirq",


### PR DESCRIPTION
The plugin-test-matrix is [currently failing](https://github.com/PennyLaneAI/plugin-test-matrix/actions?query=workflow%3Acirq-latest-rc) because this plugin is using pennylane master, which now has the version attribute set to `0.30.0.dev0` but it expects the version to be `0.29.0` (which it would be on the RC branch)