### PR TITLE
Revert "pin versions to 0.29 rc branch (#135)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ openfermion==1.1.0
 openfermionpyscf==0.5
 packaging==21.0
 pandas==1.3.3
-git+https://github.com/PennyLaneAI/pennylane.git@v0.29.0-rc0
+git+https://github.com/PennyLaneAI/pennylane.git@master
 PennyLane-Lightning==0.22.1
 Pillow==9.1.1
 pluggy==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open("pennylane_cirq/_version.py") as f:
 # Avoid pinning, and use minimum version numbers
 # only where required.
 
-requirements = ["pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@v0.29.0-rc0", "cirq-core>=0.10", "cirq-pasqal>=0.10"]
+requirements = ["pennylane @ git+https://github.com/PennyLaneAI/pennylane.git", "cirq-core>=0.10", "cirq-pasqal>=0.10"]
 
 info = {
     "name": "PennyLane-Cirq",


### PR DESCRIPTION
This reverts commit 4279e4baa2a1456007b3d90d64c70ecde7ff9ddd.

This change [broke qml](https://github.com/PennyLaneAI/qml/actions/runs/4256059628/jobs/7404470521)! Undo now that we are comfortable with plugin tests passing.

PS: the plugin tests [passed](https://github.com/PennyLaneAI/plugin-test-matrix/actions/runs/4256199317/jobs/7404766576) while this PR was not yet merged :)