### PR TITLE
Version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   [(#130)](https://github.com/PennyLaneAI/pennylane-cirq/pull/130)
 
 * Bumps the required PennyLane version to v0.29.0.
+  [(#137)](https://github.com/PennyLaneAI/pennylane-cirq/pull/137)
 
 ### Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,6 @@ Christina Lee
   plugin's custom support because PennyLane supports them.
   [(#115)](https://github.com/PennyLaneAI/pennylane-cirq/pull/115)
 
-* Require PennyLane of at least v0.29.
-
 ### Improvements
 
 * Pass all the qubits as `qubit_order` parameter to force 
@@ -68,7 +66,7 @@ Christina Lee
 
 This release contains contributions from (in alphabetical order):
 
-Christina Lee, Oumarou Oumarou, Matthew Silverman
+Oumarou Oumarou, Matthew Silverman
 
 ---
 # Release 0.24.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,15 @@
   Note that the `inv()` method and `inverse` property are removed from PennyLane operators as of PennyLane 0.29.
   [(#130)](https://github.com/PennyLaneAI/pennylane-cirq/pull/130)
 
+* Bumps the required PennyLane version to v0.29.0.
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-Matthew Silverman
+Christina Lee, Matthew Silverman
 
+---
 # Release 0.28.0
 
 ### New features since last release

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,8 +28,8 @@ openfermion==1.1.0
 openfermionpyscf==0.5
 packaging==21.0
 pandas==1.3.3
-git+https://github.com/PennyLaneAI/pennylane.git@master
-PennyLane-Lightning==0.22.1
+pennylane==0.29.0
+PennyLane-Lightning==0.29.0
 Pillow==9.1.1
 pluggy==1.0.0
 protobuf==3.15.0


### PR DESCRIPTION
This PR fixes the changelog for an accidental push to master: https://github.com/PennyLaneAI/pennylane-cirq/commit/2ae8c3921ad437a95bd4543fdd6690eee263abf8

Basically, we just need to bump the PL requires version to 0.29.0