### PR TITLE
fix test to not fail with new shots validation

### DIFF
--- a/tests/test_mixed_simulator_device.py
+++ b/tests/test_mixed_simulator_device.py
@@ -452,7 +452,7 @@ class TestApply:
             )
 
 
-@pytest.mark.parametrize("shots", [(100, False)])
+@pytest.mark.parametrize("shots", [100])
 class TestStatePreparationErrorsNonAnalytic:
     """Tests state preparation errors that occur for non-analytic devices."""
 


### PR DESCRIPTION
this test was halfway-fixed to stop using the `analytic` keyword once upon a time, but the `False` was accidentally left behind. With the new validation (introduced in PennylaneAI/pennylane#4169) in `_device.py` when setting shots, this failed suddenly!