### PR TITLE
Remove do queue

### DIFF
--- a/tests/test_mixed_simulator_device.py
+++ b/tests/test_mixed_simulator_device.py
@@ -523,7 +523,7 @@ class TestExpval:
     ):
         """Tests that expectation values are properly calculated for single-wire observables without parameters."""
 
-        op = operation(0, do_queue=False)
+        op = operation(0)
 
         simulator_device_1_wire.reset()
         simulator_device_1_wire.apply(
@@ -552,7 +552,7 @@ class TestExpval:
     ):
         """Tests that expectation values are properly calculated for single-wire observables with parameters."""
 
-        op = operation(par[0], 0, do_queue=False)
+        op = operation(par[0], 0)
 
         simulator_device_1_wire.reset()
         simulator_device_1_wire.apply(
@@ -638,7 +638,7 @@ class TestExpval:
     ):
         """Tests that expectation values are properly calculated for two-wire observables with parameters."""
 
-        op = operation(par[0], [0, 1], do_queue=False)
+        op = operation(par[0], [0, 1])
 
         simulator_device_2_wires.reset()
         simulator_device_2_wires.apply(
@@ -722,7 +722,7 @@ class TestVar:
     ):
         """Tests that variances are properly calculated for single-wire observables without parameters."""
 
-        op = operation(0, do_queue=False)
+        op = operation(0)
 
         simulator_device_1_wire.reset()
         simulator_device_1_wire.apply(
@@ -756,9 +756,9 @@ class TestVar:
         """Tests that expectation values are properly calculated for single-wire observables with parameters."""
 
         if par:
-            op = operation(np.array(*par), 0, do_queue=False)
+            op = operation(np.array(*par), 0)
         else:
-            op = operation(0, do_queue=False)
+            op = operation(0)
 
         simulator_device_1_wire.reset()
         simulator_device_1_wire.apply(
@@ -813,7 +813,7 @@ class TestVar:
     ):
         """Tests that variances are properly calculated for two-wire observables with parameters."""
 
-        op = operation(np.array(*par), [0, 1], do_queue=False)
+        op = operation(np.array(*par), [0, 1])
 
         simulator_device_2_wires.reset()
         simulator_device_2_wires.apply(

--- a/tests/test_qsim_device.py
+++ b/tests/test_qsim_device.py
@@ -369,7 +369,7 @@ class TestExpval:
     ):
         """Tests that expectation values are properly calculated for single-wire observables with parameters."""
 
-        op = operation(par[0], 0, do_queue=False)
+        op = operation(par[0], 0)
 
         qsim_device_1_wire.reset()
 
@@ -444,7 +444,7 @@ class TestExpval:
     ):
         """Tests that expectation values are properly calculated for two-wire observables with parameters."""
 
-        op = operation(par[0], [0, 1], do_queue=False)
+        op = operation(par[0], [0, 1])
 
         qsim_device_2_wires.reset()
 
@@ -476,7 +476,7 @@ class TestVar:
     ):
         """Tests that variances are properly calculated for single-wire observables without parameters."""
 
-        op = operation(0, do_queue=False)
+        op = operation(0)
 
         qsim_device_1_wire.reset()
         qsim_device_1_wire.apply(op.diagonalizing_gates())
@@ -499,9 +499,9 @@ class TestVar:
         """Tests that expectation values are properly calculated for single-wire observables with parameters."""
 
         if par:
-            op = operation(np.array(*par), 0, do_queue=False)
+            op = operation(np.array(*par), 0)
         else:
-            op = operation(0, do_queue=False)
+            op = operation(0)
 
         qsim_device_1_wire.reset()
         if basis_state:
@@ -530,7 +530,7 @@ class TestVar:
     ):
         """Tests that variances are properly calculated for two-wire observables with parameters."""
 
-        op = operation(np.array(*par), [0, 1], do_queue=False)
+        op = operation(np.array(*par), [0, 1])
 
         qsim_device_2_wires.reset()
         qsim_device_2_wires.apply(op.diagonalizing_gates())

--- a/tests/test_qsimh_device.py
+++ b/tests/test_qsimh_device.py
@@ -284,7 +284,7 @@ class TestExpval:
     ):
         """Tests that expectation values are properly calculated for single-wire observables without parameters."""
 
-        op = operation(0, do_queue=False)
+        op = operation(0)
 
         qsimh_device_1_wire.reset()
 
@@ -308,7 +308,7 @@ class TestExpval:
     ):
         """Tests that expectation values are properly calculated for single-wire observables with parameters."""
 
-        op = operation(par[0], 0, do_queue=False)
+        op = operation(par[0], 0)
 
         qsimh_device_1_wire.reset()
 
@@ -339,7 +339,7 @@ class TestVar:
     ):
         """Tests that variances are properly calculated for single-wire observables without parameters."""
 
-        op = operation(0, do_queue=False)
+        op = operation(0)
 
         qsimh_device_1_wire.reset()
         qsimh_device_1_wire.apply(op.diagonalizing_gates())
@@ -362,9 +362,9 @@ class TestVar:
         """Tests that expectation values are properly calculated for single-wire observables with parameters."""
 
         if par:
-            op = operation(np.array(*par), 0, do_queue=False)
+            op = operation(np.array(*par), 0)
         else:
-            op = operation(0, do_queue=False)
+            op = operation(0)
 
         qsimh_device_1_wire.reset()
         if basis_state:

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -50,7 +50,7 @@ class TestSample:
         with mimic_execution_for_sample(dev):
             dev.apply([qml.RX(1.5708, wires=[0])])
 
-        dev._obs_queue = [qml.PauliZ(wires=[0], do_queue=False)]
+        dev._obs_queue = [qml.PauliZ(wires=[0])]
 
         for idx in range(len(dev._obs_queue)):
             dev._obs_queue[idx].return_type = qml.measurements.Sample
@@ -72,10 +72,10 @@ class TestSample:
         with mimic_execution_for_sample(dev):
             dev.apply(
                 [qml.RX(theta, wires=[0])],
-                rotations=qml.Hermitian(A, wires=[0], do_queue=False).diagonalizing_gates(),
+                rotations=qml.Hermitian(A, wires=[0]).diagonalizing_gates(),
             )
 
-        dev._obs_queue = [qml.Hermitian(A, wires=[0], do_queue=False)]
+        dev._obs_queue = [qml.Hermitian(A, wires=[0])]
 
         for idx in range(len(dev._obs_queue)):
             dev._obs_queue[idx].return_type = qml.measurements.Sample
@@ -104,7 +104,7 @@ class TestSample:
         with mimic_execution_for_sample(dev):
             dev.apply([qml.RX(theta, wires=[0])])
 
-        dev._obs_queue = [qml.Projector([0], wires=0, do_queue=False)]
+        dev._obs_queue = [qml.Projector([0], wires=0)]
         dev._obs_queue[0].return_type = qml.measurements.Sample
         s1 = dev.sample(qml.Projector([0], wires=[0]))
         # s1 should only contain 0 or 1, the eigenvalues of the projector
@@ -114,7 +114,7 @@ class TestSample:
             np.var(s1), np.cos(theta / 2) ** 2 - (np.cos(theta / 2) ** 2) ** 2, **tol
         )
 
-        dev._obs_queue = [qml.Projector([1], wires=0, do_queue=False)]
+        dev._obs_queue = [qml.Projector([1], wires=0)]
         dev._obs_queue[0].return_type = qml.measurements.Sample
         s1 = dev.sample(qml.Projector([1], wires=[0]))
         assert np.allclose(sorted(list(set(s1))), [0, 1], **tol)
@@ -146,10 +146,10 @@ class TestSample:
                     qml.RY(2 * theta, wires=[1]),
                     qml.CNOT(wires=[0, 1]),
                 ],
-                rotations=qml.Hermitian(A, wires=[0, 1], do_queue=False).diagonalizing_gates(),
+                rotations=qml.Hermitian(A, wires=[0, 1]).diagonalizing_gates(),
             )
 
-        dev._obs_queue = [qml.Hermitian(A, wires=[0, 1], do_queue=False)]
+        dev._obs_queue = [qml.Hermitian(A, wires=[0, 1])]
 
         for idx in range(len(dev._obs_queue)):
             dev._obs_queue[idx].return_type = qml.measurements.Sample
@@ -189,7 +189,7 @@ class TestSample:
                 ]
             )
 
-        dev._obs_queue = [qml.Projector([0, 0], wires=[0, 1], do_queue=False)]
+        dev._obs_queue = [qml.Projector([0, 0], wires=[0, 1])]
         dev._obs_queue[0].return_type = qml.measurements.Sample
         s1 = dev.sample(qml.Projector([0, 0], wires=[0, 1]))
         # s1 should only contain 0 or 1, the eigenvalues of the projector
@@ -197,21 +197,21 @@ class TestSample:
         expected = (np.cos(theta / 2) * np.cos(theta)) ** 2
         assert np.allclose(np.mean(s1), expected, **tol)
 
-        dev._obs_queue = [qml.Projector([0, 1], wires=[0, 1], do_queue=False)]
+        dev._obs_queue = [qml.Projector([0, 1], wires=[0, 1])]
         dev._obs_queue[0].return_type = qml.measurements.Sample
         s1 = dev.sample(qml.Projector([0, 1], wires=[0, 1]))
         assert np.allclose(sorted(list(set(s1))), [0, 1], **tol)
         expected = (np.cos(theta / 2) * np.sin(theta)) ** 2
         assert np.allclose(np.mean(s1), expected, **tol)
 
-        dev._obs_queue = [qml.Projector([1, 0], wires=[0, 1], do_queue=False)]
+        dev._obs_queue = [qml.Projector([1, 0], wires=[0, 1])]
         dev._obs_queue[0].return_type = qml.measurements.Sample
         s1 = dev.sample(qml.Projector([1, 0], wires=[0, 1]))
         assert np.allclose(sorted(list(set(s1))), [0, 1], **tol)
         expected = (np.sin(theta / 2) * np.sin(theta)) ** 2
         assert np.allclose(np.mean(s1), expected, **tol)
 
-        dev._obs_queue = [qml.Projector([1, 1], wires=[0, 1], do_queue=False)]
+        dev._obs_queue = [qml.Projector([1, 1], wires=[0, 1])]
         dev._obs_queue[0].return_type = qml.measurements.Sample
         s1 = dev.sample(qml.Projector([1, 1], wires=[0, 1]))
         assert np.allclose(sorted(list(set(s1))), [0, 1], **tol)
@@ -241,7 +241,7 @@ class TestTensorSample:
         varphi = -0.543
 
         dev = device(3)
-        obs = qml.PauliX(wires=[0], do_queue=False) @ qml.PauliY(wires=[2], do_queue=False)
+        obs = qml.PauliX(wires=[0]) @ qml.PauliY(wires=[2])
 
         with mimic_execution_for_sample(dev):
             dev.apply(
@@ -284,9 +284,9 @@ class TestTensorSample:
         dev = device(3)
 
         obs = (
-            qml.PauliZ(wires=[0], do_queue=False)
-            @ qml.Hadamard(wires=[1], do_queue=False)
-            @ qml.PauliY(wires=[2], do_queue=False)
+            qml.PauliZ(wires=[0])
+            @ qml.Hadamard(wires=[1])
+            @ qml.PauliY(wires=[2])
         )
 
         with mimic_execution_for_sample(dev):
@@ -339,7 +339,7 @@ class TestTensorSample:
             ]
         )
 
-        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Hermitian(A, wires=[1, 2], do_queue=False)
+        obs = qml.PauliZ(wires=[0]) @ qml.Hermitian(A, wires=[1, 2])
 
         with mimic_execution_for_sample(dev):
             dev.apply(
@@ -425,8 +425,8 @@ class TestTensorSample:
                 ]
             )
 
-        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Projector(
-            [0, 0], wires=[1, 2], do_queue=False
+        obs = qml.PauliZ(wires=[0]) @ qml.Projector(
+            [0, 0], wires=[1, 2]
         )
         s1 = dev.sample(obs)
         # s1 should only contain the eigenvalues of the projector matrix tensor product Z, i.e. {-1, 0, 1}
@@ -448,8 +448,8 @@ class TestTensorSample:
         )
         assert np.allclose(var, expected, **tol)
 
-        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Projector(
-            [0, 1], wires=[1, 2], do_queue=False
+        obs = qml.PauliZ(wires=[0]) @ qml.Projector(
+            [0, 1], wires=[1, 2]
         )
         s1 = dev.sample(obs)
         assert np.allclose(sorted(list(set(s1))), [-1, 0, 1], **tol)
@@ -470,8 +470,8 @@ class TestTensorSample:
         )
         assert np.allclose(var, expected, **tol)
 
-        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Projector(
-            [1, 0], wires=[1, 2], do_queue=False
+        obs = qml.PauliZ(wires=[0]) @ qml.Projector(
+            [1, 0], wires=[1, 2]
         )
         s1 = dev.sample(obs)
         assert np.allclose(sorted(list(set(s1))), [-1, 0, 1], **tol)
@@ -492,8 +492,8 @@ class TestTensorSample:
         )
         assert np.allclose(var, expected, **tol)
 
-        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Projector(
-            [1, 1], wires=[1, 2], do_queue=False
+        obs = qml.PauliZ(wires=[0]) @ qml.Projector(
+            [1, 1], wires=[1, 2]
         )
         s1 = dev.sample(obs)
         assert np.allclose(sorted(list(set(s1))), [-1, 0, 1], **tol)

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -425,9 +425,7 @@ class TestTensorSample:
                 ]
             )
 
-        obs = qml.PauliZ(wires=[0]) @ qml.Projector(
-            [0, 0], wires=[1, 2]
-        )
+        obs = qml.PauliZ(wires=[0]) @ qml.Projector([0, 0], wires=[1, 2])
         s1 = dev.sample(obs)
         # s1 should only contain the eigenvalues of the projector matrix tensor product Z, i.e. {-1, 0, 1}
         assert np.allclose(sorted(list(set(s1))), [-1, 0, 1], **tol)
@@ -448,9 +446,7 @@ class TestTensorSample:
         )
         assert np.allclose(var, expected, **tol)
 
-        obs = qml.PauliZ(wires=[0]) @ qml.Projector(
-            [0, 1], wires=[1, 2]
-        )
+        obs = qml.PauliZ(wires=[0]) @ qml.Projector([0, 1], wires=[1, 2])
         s1 = dev.sample(obs)
         assert np.allclose(sorted(list(set(s1))), [-1, 0, 1], **tol)
         mean = np.mean(s1)
@@ -470,9 +466,7 @@ class TestTensorSample:
         )
         assert np.allclose(var, expected, **tol)
 
-        obs = qml.PauliZ(wires=[0]) @ qml.Projector(
-            [1, 0], wires=[1, 2]
-        )
+        obs = qml.PauliZ(wires=[0]) @ qml.Projector([1, 0], wires=[1, 2])
         s1 = dev.sample(obs)
         assert np.allclose(sorted(list(set(s1))), [-1, 0, 1], **tol)
         mean = np.mean(s1)
@@ -492,9 +486,7 @@ class TestTensorSample:
         )
         assert np.allclose(var, expected, **tol)
 
-        obs = qml.PauliZ(wires=[0]) @ qml.Projector(
-            [1, 1], wires=[1, 2]
-        )
+        obs = qml.PauliZ(wires=[0]) @ qml.Projector([1, 1], wires=[1, 2])
         s1 = dev.sample(obs)
         assert np.allclose(sorted(list(set(s1))), [-1, 0, 1], **tol)
         mean = np.mean(s1)

--- a/tests/test_simulator_device.py
+++ b/tests/test_simulator_device.py
@@ -556,7 +556,7 @@ class TestExpval:
     ):
         """Tests that expectation values are properly calculated for single-wire observables without parameters."""
 
-        op = operation(0, do_queue=False)
+        op = operation(0)
 
         simulator_device_1_wire.reset()
         simulator_device_1_wire.apply(
@@ -585,7 +585,7 @@ class TestExpval:
     ):
         """Tests that expectation values are properly calculated for single-wire observables with parameters."""
 
-        op = operation(par[0], 0, do_queue=False)
+        op = operation(par[0], 0)
 
         simulator_device_1_wire.reset()
         simulator_device_1_wire.apply(
@@ -671,7 +671,7 @@ class TestExpval:
     ):
         """Tests that expectation values are properly calculated for two-wire observables with parameters."""
 
-        op = operation(par[0], [0, 1], do_queue=False)
+        op = operation(par[0], [0, 1])
 
         simulator_device_2_wires.reset()
         simulator_device_2_wires.apply(
@@ -710,7 +710,7 @@ class TestVar:
     ):
         """Tests that variances are properly calculated for single-wire observables without parameters."""
 
-        op = operation(0, do_queue=False)
+        op = operation(0)
 
         simulator_device_1_wire.reset()
         simulator_device_1_wire.apply(
@@ -744,9 +744,9 @@ class TestVar:
         """Tests that expectation values are properly calculated for single-wire observables with parameters."""
 
         if par:
-            op = operation(np.array(*par), 0, do_queue=False)
+            op = operation(np.array(*par), 0)
         else:
-            op = operation(0, do_queue=False)
+            op = operation(0)
 
         simulator_device_1_wire.reset()
         simulator_device_1_wire.apply(
@@ -797,7 +797,7 @@ class TestVar:
     ):
         """Tests that variances are properly calculated for two-wire observables with parameters."""
 
-        op = operation(np.array(*par), [0, 1], do_queue=False)
+        op = operation(np.array(*par), [0, 1])
 
         simulator_device_2_wires.reset()
         simulator_device_2_wires.apply(

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -52,7 +52,7 @@ class TestVar:
             dev.apply([qml.RX(phi, wires=[0]), qml.RY(theta, wires=[0])])
 
         # Here the observable is already diagonal
-        var = dev.var(qml.PauliZ(wires=[0], do_queue=False))
+        var = dev.var(qml.PauliZ(wires=[0]))
         expected = 0.25 * (3 - np.cos(2 * theta) - 2 * np.cos(theta) ** 2 * np.cos(2 * phi))
 
         assert np.allclose(var, expected, **tol)
@@ -67,7 +67,7 @@ class TestVar:
 
         # test correct variance for <H> of a rotated state
         H = np.array([[4, -1 + 6j], [-1 - 6j, 2]])
-        obs = qml.Hermitian(H, wires=[0], do_queue=False)
+        obs = qml.Hermitian(H, wires=[0])
 
         with mimic_execution_for_var(dev):
             dev.apply(
@@ -95,28 +95,28 @@ class TestVar:
         with mimic_execution_for_var(dev):
             dev.apply([qml.RX(phi, wires=[0]), qml.RY(theta, wires=[1]), qml.CNOT(wires=[0, 1])])
 
-        obs = qml.Projector([0, 0], wires=[0, 1], do_queue=False)
+        obs = qml.Projector([0, 0], wires=[0, 1])
         var = dev.var(obs)
         expected = (np.cos(phi / 2) * np.cos(theta / 2)) ** 2 - (
             (np.cos(phi / 2) * np.cos(theta / 2)) ** 2
         ) ** 2
         assert np.allclose(var, expected, **tol)
 
-        obs = qml.Projector([0, 1], wires=[0, 1], do_queue=False)
+        obs = qml.Projector([0, 1], wires=[0, 1])
         var = dev.var(obs)
         expected = (np.cos(phi / 2) * np.sin(theta / 2)) ** 2 - (
             (np.cos(phi / 2) * np.sin(theta / 2)) ** 2
         ) ** 2
         assert np.allclose(var, expected, **tol)
 
-        obs = qml.Projector([1, 0], wires=[0, 1], do_queue=False)
+        obs = qml.Projector([1, 0], wires=[0, 1])
         var = dev.var(obs)
         expected = (np.sin(phi / 2) * np.sin(theta / 2)) ** 2 - (
             (np.sin(phi / 2) * np.sin(theta / 2)) ** 2
         ) ** 2
         assert np.allclose(var, expected, **tol)
 
-        obs = qml.Projector([1, 1], wires=[0, 1], do_queue=False)
+        obs = qml.Projector([1, 1], wires=[0, 1])
         var = dev.var(obs)
         expected = (np.sin(phi / 2) * np.cos(theta / 2)) ** 2 - (
             (np.sin(phi / 2) * np.cos(theta / 2)) ** 2
@@ -135,7 +135,7 @@ class TestTensorVar:
         varphi = -0.543
 
         dev = device(3)
-        obs = qml.PauliX(wires=[0], do_queue=False) @ qml.PauliY(wires=[2], do_queue=False)
+        obs = qml.PauliX(wires=[0]) @ qml.PauliY(wires=[2])
 
         with mimic_execution_for_var(dev):
             dev.apply(
@@ -171,9 +171,9 @@ class TestTensorVar:
         dev = device(3)
 
         obs = (
-            qml.PauliZ(wires=[0], do_queue=False)
-            @ qml.Hadamard(wires=[1], do_queue=False)
-            @ qml.PauliY(wires=[2], do_queue=False)
+            qml.PauliZ(wires=[0])
+            @ qml.Hadamard(wires=[1])
+            @ qml.PauliY(wires=[2])
         )
 
         with mimic_execution_for_var(dev):
@@ -215,7 +215,7 @@ class TestTensorVar:
                 [-5 - 2j, -5 - 4j, -4 - 3j, -6],
             ]
         )
-        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Hermitian(A, wires=[1, 2], do_queue=False)
+        obs = qml.PauliZ(wires=[0]) @ qml.Hermitian(A, wires=[1, 2])
 
         with mimic_execution_for_var(dev):
             dev.apply(
@@ -283,8 +283,8 @@ class TestTensorVar:
                 ]
             )
 
-        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Projector(
-            [0, 0], wires=[1, 2], do_queue=False
+        obs = qml.PauliZ(wires=[0]) @ qml.Projector(
+            [0, 0], wires=[1, 2]
         )
         res = dev.var(obs)
         expected = (
@@ -296,8 +296,8 @@ class TestTensorVar:
         ) ** 2
         assert np.allclose(res, expected, **tol)
 
-        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Projector(
-            [0, 1], wires=[1, 2], do_queue=False
+        obs = qml.PauliZ(wires=[0]) @ qml.Projector(
+            [0, 1], wires=[1, 2]
         )
         res = dev.var(obs)
         expected = (
@@ -309,8 +309,8 @@ class TestTensorVar:
         ) ** 2
         assert np.allclose(res, expected, **tol)
 
-        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Projector(
-            [1, 0], wires=[1, 2], do_queue=False
+        obs = qml.PauliZ(wires=[0]) @ qml.Projector(
+            [1, 0], wires=[1, 2]
         )
         res = dev.var(obs)
         expected = (
@@ -322,8 +322,8 @@ class TestTensorVar:
         ) ** 2
         assert np.allclose(res, expected, **tol)
 
-        obs = qml.PauliZ(wires=[0], do_queue=False) @ qml.Projector(
-            [1, 1], wires=[1, 2], do_queue=False
+        obs = qml.PauliZ(wires=[0]) @ qml.Projector(
+            [1, 1], wires=[1, 2]
         )
         res = dev.var(obs)
         expected = (

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -283,9 +283,7 @@ class TestTensorVar:
                 ]
             )
 
-        obs = qml.PauliZ(wires=[0]) @ qml.Projector(
-            [0, 0], wires=[1, 2]
-        )
+        obs = qml.PauliZ(wires=[0]) @ qml.Projector([0, 0], wires=[1, 2])
         res = dev.var(obs)
         expected = (
             (np.cos(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2
@@ -296,9 +294,7 @@ class TestTensorVar:
         ) ** 2
         assert np.allclose(res, expected, **tol)
 
-        obs = qml.PauliZ(wires=[0]) @ qml.Projector(
-            [0, 1], wires=[1, 2]
-        )
+        obs = qml.PauliZ(wires=[0]) @ qml.Projector([0, 1], wires=[1, 2])
         res = dev.var(obs)
         expected = (
             (np.sin(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2
@@ -309,9 +305,7 @@ class TestTensorVar:
         ) ** 2
         assert np.allclose(res, expected, **tol)
 
-        obs = qml.PauliZ(wires=[0]) @ qml.Projector(
-            [1, 0], wires=[1, 2]
-        )
+        obs = qml.PauliZ(wires=[0]) @ qml.Projector([1, 0], wires=[1, 2])
         res = dev.var(obs)
         expected = (
             (np.sin(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2
@@ -322,9 +316,7 @@ class TestTensorVar:
         ) ** 2
         assert np.allclose(res, expected, **tol)
 
-        obs = qml.PauliZ(wires=[0]) @ qml.Projector(
-            [1, 1], wires=[1, 2]
-        )
+        obs = qml.PauliZ(wires=[0]) @ qml.Projector([1, 1], wires=[1, 2])
         res = dev.var(obs)
         expected = (
             (np.cos(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2


### PR DESCRIPTION
The `do_queue` argument has been removed from PennyLane. Here we remove `do_queue=False` from the tests for the plugin.