### PR TITLE
Add `StatePrep` support

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install dependencies
         run: pip install black

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.9, '3.10', '3.11']
 
     steps:
       - name: Cancel Previous Runs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,7 +19,7 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
+  version: 3.9
   install:
     - requirements: doc/requirements.txt
     - method: pip

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,11 +19,14 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.9
   install:
     - requirements: doc/requirements.txt
     - method: pip
       path: .
 
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+  apt_packages:
+    - graphviz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Bug fixes 🐛
 
 * The plugin is updated to take `qml.StatePrep` operators, the new name for `qml.QubitStateVector`.
+  [(#126)](https://github.com/PennyLaneAI/pennylane-cirq/pull/146)
 
 ### Contributors ✍️
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Breaking changes 💔
 
+* Python 3.8 support is dropped and Python 3.11 support is added.
+  [(#126)](https://github.com/PennyLaneAI/pennylane-cirq/pull/146)
+
 ### Deprecations 👋
 
 ### Documentation 📝

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release 0.32.0
+# Release 0.32.0-dev
 
 ### New features since last release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release 0.32.0-dev
+# Release 0.32.0
 
 ### New features since last release
 
@@ -12,9 +12,13 @@
 
 ### Bug fixes 🐛
 
+* The plugin is updated to take `qml.StatePrep` operators, the new name for `qml.QubitStateVector`.
+
 ### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
+
+Christina Lee
 
 ---
 # Release 0.31.0

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Features
 Installation
 ============
 
-This plugin requires Python version 3.8 or above, as well as PennyLane
+This plugin requires Python version 3.9 or above, as well as PennyLane
 and Cirq. Installation of this plugin, as well as all dependencies, can be done using ``pip``:
 
 .. code-block:: bash
@@ -76,7 +76,7 @@ Dependencies
 
 PennyLane-Cirq requires the following libraries be installed:
 
-* `Python <http://python.org/>`__ >= 3.8
+* `Python <http://python.org/>`__ >= 3.9
 
 as well as the following Python packages:
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -58,7 +58,7 @@ pytz==2021.1
 PyYAML==6.0
 requests==2.27.1
 retworkx==0.11.0
-scipy==1.7.3
+scipy==1.11.2
 semantic-version==2.10
 six==1.16.0
 snowballstemmer==2.2.0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -75,7 +75,7 @@ sympy==1.9
 toml==0.10.2
 tqdm==4.64.0
 traitlets==5.1.0
-typing_extensions==3.10.0.0
+typing_extensions==4.2.0
 urllib3==1.26.9
 # Do not pin the following
 pennylane-sphinx-theme

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -118,6 +118,7 @@ class CirqDevice(QubitDevice, abc.ABC):
         **{f"Pow({k})": v for k, v in _pow_operation_map.items()},
         "BasisState": None,
         "QubitStateVector": None,
+        "StatePrep": None,
         "QubitUnitary": CirqOperation(cirq.MatrixGate),
         "PauliX": CirqOperation(lambda: cirq.X),
         "PauliY": CirqOperation(lambda: cirq.Y),
@@ -271,14 +272,14 @@ class CirqDevice(QubitDevice, abc.ABC):
         rotations = kwargs.pop("rotations", [])
 
         for i, operation in enumerate(operations):
-            if i > 0 and operation.name in {"BasisState", "QubitStateVector"}:
+            if i > 0 and operation.name in {"BasisState", "QubitStateVector", "StatePrep"}:
                 raise qml.DeviceError(
                     f"The operation {operation.name} is only supported at the beginning of a circuit."
                 )
 
             if operation.name == "BasisState":
                 self._apply_basis_state(operation)
-            elif operation.name == "QubitStateVector":
+            elif operation.name in {"StatePrep", "QubitStateVector"}:
                 self._apply_qubit_state_vector(operation)
             else:
                 self._apply_operation(operation)

--- a/pennylane_cirq/qsim_device.py
+++ b/pennylane_cirq/qsim_device.py
@@ -67,6 +67,7 @@ class QSimDevice(SimulatorDevice):
         # pylint: disable=missing-function-docstring
         return set(self._base_operation_map) - {
             "QubitStateVector",
+            "StatePrep",
             "BasisState",
             "CRX",
             "CRY",
@@ -122,6 +123,7 @@ class QSimhDevice(SimulatorDevice):
         # pylint: disable=missing-function-docstring
         return set(self._base_operation_map) - {
             "QubitStateVector",
+            "StatePrep",
             "BasisState",
             "CRX",
             "CRY",

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -94,7 +94,7 @@ class SimulatorDevice(CirqDevice):
         # pylint: disable=missing-function-docstring
         if self.shots is not None:
             raise qml.DeviceError(
-                "The operation QubitStateVector is only supported in analytic mode."
+                "The operations StatePrep and QubitStateVector is only supported in analytic mode."
             )
 
         self._initial_state = qubit_state_vector_operation.state_vector(

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -94,7 +94,7 @@ class SimulatorDevice(CirqDevice):
         # pylint: disable=missing-function-docstring
         if self.shots is not None:
             raise qml.DeviceError(
-                "The operations StatePrep and QubitStateVector is only supported in analytic mode."
+                "The operations StatePrep and QubitStateVector are only supported in analytic mode."
             )
 
         self._initial_state = qubit_state_vector_operation.state_vector(

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -79,7 +79,7 @@ class SimulatorDevice(CirqDevice):
     def capabilities(self):  # pylint: disable=missing-function-docstring
         capabilities = super().capabilities().copy()
         capabilities.update(
-            returns_state=(self.shots is None)  # State information is only set if obtaining shots
+            returns_state=self.shots is None  # State information is only set if obtaining shots
         )
         return capabilities
 
@@ -240,7 +240,7 @@ class MixedStateSimulatorDevice(SimulatorDevice):
     def capabilities(self):  # pylint: disable=missing-function-docstring
         capabilities = super().capabilities().copy()
         capabilities.update(
-            returns_state=(self.shots is None)  # State information is only set if obtaining shots
+            returns_state=self.shots is None  # State information is only set if obtaining shots
         )
         return capabilities
 

--- a/setup.py
+++ b/setup.py
@@ -62,9 +62,9 @@ classifiers = [
     "Programming Language :: Python",
     # Make sure to specify here the versions of Python supported
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering :: Physics",
 ]

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -112,7 +112,7 @@ class TestApplyPureState:
         state = init_state(1)
 
         with mimic_execution_for_apply(dev):
-            dev.apply([qml.QubitStateVector(state, wires=[0])])
+            dev.apply([qml.StatePrep(state, wires=[0])])
 
         res = dev._state
         expected = state
@@ -127,7 +127,7 @@ class TestApplyPureState:
         with mimic_execution_for_apply(dev):
             dev.apply(
                 [
-                    qml.QubitStateVector(state, wires=[0]),
+                    qml.StatePrep(state, wires=[0]),
                     qml.__getattribute__(name)(wires=[0]),
                 ]
             )
@@ -146,7 +146,7 @@ class TestApplyPureState:
         with mimic_execution_for_apply(dev):
             dev.apply(
                 [
-                    qml.QubitStateVector(state, wires=[0]),
+                    qml.StatePrep(state, wires=[0]),
                     qml.__getattribute__(name)(theta, wires=[0]),
                 ]
             )
@@ -165,7 +165,7 @@ class TestApplyPureState:
         c = -0.654
 
         with mimic_execution_for_apply(dev):
-            dev.apply([qml.QubitStateVector(state, wires=[0]), qml.Rot(a, b, c, wires=[0])])
+            dev.apply([qml.StatePrep(state, wires=[0]), qml.Rot(a, b, c, wires=[0])])
 
         res = dev._state
         expected = rot(a, b, c) @ state
@@ -180,7 +180,7 @@ class TestApplyPureState:
         with mimic_execution_for_apply(dev):
             dev.apply(
                 [
-                    qml.QubitStateVector(state, wires=[0, 1]),
+                    qml.StatePrep(state, wires=[0, 1]),
                     qml.__getattribute__(name)(wires=[0, 1]),
                 ]
             )
@@ -198,7 +198,7 @@ class TestApplyPureState:
         with mimic_execution_for_apply(dev):
             dev.apply(
                 [
-                    qml.QubitStateVector(state, wires=list(range(N))),
+                    qml.StatePrep(state, wires=list(range(N))),
                     qml.QubitUnitary(mat, wires=list(range(N))),
                 ]
             )
@@ -225,7 +225,7 @@ class TestApplyPureState:
         with mimic_execution_for_apply(dev):
             dev.apply(
                 [
-                    qml.QubitStateVector(state, wires=[0, 1, 2]),
+                    qml.StatePrep(state, wires=[0, 1, 2]),
                     qml.__getattribute__(name)(wires=[0, 1, 2]),
                 ]
             )
@@ -244,7 +244,7 @@ class TestApplyPureState:
         with mimic_execution_for_apply(dev):
             dev.apply(
                 [
-                    qml.QubitStateVector(state, wires=[0, 1]),
+                    qml.StatePrep(state, wires=[0, 1]),
                     qml.__getattribute__(name)(theta, wires=[0, 1]),
                 ]
             )
@@ -294,7 +294,7 @@ class TestApplyMixedState:
         state = init_state(1)
 
         with mimic_execution_for_apply(dev):
-            dev.apply([qml.QubitStateVector(state, wires=[0])])
+            dev.apply([qml.StatePrep(state, wires=[0])])
 
         res = dev._state
         expected = state
@@ -310,7 +310,7 @@ class TestApplyMixedState:
         with mimic_execution_for_apply(dev):
             dev.apply(
                 [
-                    qml.QubitStateVector(state, wires=[0]),
+                    qml.StatePrep(state, wires=[0]),
                     qml.__getattribute__(name)(wires=[0]),
                 ]
             )
@@ -330,7 +330,7 @@ class TestApplyMixedState:
         with mimic_execution_for_apply(dev):
             dev.apply(
                 [
-                    qml.QubitStateVector(state, wires=[0]),
+                    qml.StatePrep(state, wires=[0]),
                     qml.__getattribute__(name)(theta, wires=[0]),
                 ]
             )
@@ -350,7 +350,7 @@ class TestApplyMixedState:
         c = -0.654
 
         with mimic_execution_for_apply(dev):
-            dev.apply([qml.QubitStateVector(state, wires=[0]), qml.Rot(a, b, c, wires=[0])])
+            dev.apply([qml.StatePrep(state, wires=[0]), qml.Rot(a, b, c, wires=[0])])
 
         res = dev._state
         expected = rot(a, b, c) @ state
@@ -366,7 +366,7 @@ class TestApplyMixedState:
         with mimic_execution_for_apply(dev):
             dev.apply(
                 [
-                    qml.QubitStateVector(state, wires=[0, 1]),
+                    qml.StatePrep(state, wires=[0, 1]),
                     qml.__getattribute__(name)(wires=[0, 1]),
                 ]
             )
@@ -385,7 +385,7 @@ class TestApplyMixedState:
         with mimic_execution_for_apply(dev):
             dev.apply(
                 [
-                    qml.QubitStateVector(state, wires=list(range(N))),
+                    qml.StatePrep(state, wires=list(range(N))),
                     qml.QubitUnitary(mat, wires=list(range(N))),
                 ]
             )
@@ -413,7 +413,7 @@ class TestApplyMixedState:
         with mimic_execution_for_apply(dev):
             dev.apply(
                 [
-                    qml.QubitStateVector(state, wires=[0, 1, 2]),
+                    qml.StatePrep(state, wires=[0, 1, 2]),
                     qml.__getattribute__(name)(wires=[0, 1, 2]),
                 ]
             )
@@ -433,7 +433,7 @@ class TestApplyMixedState:
         with mimic_execution_for_apply(dev):
             dev.apply(
                 [
-                    qml.QubitStateVector(state, wires=[0, 1]),
+                    qml.StatePrep(state, wires=[0, 1]),
                     qml.__getattribute__(name)(theta, wires=[0, 1]),
                 ]
             )

--- a/tests/test_mixed_simulator_device.py
+++ b/tests/test_mixed_simulator_device.py
@@ -446,7 +446,7 @@ class TestApply:
 
         with pytest.raises(
             qml.DeviceError,
-            match="The operation StatePrep is only supported at the beginning of a circuit.",
+            match=f"The operation {stateprep.__name__} is only supported at the beginning of a circuit.",
         ):
             simulator_device_1_wire.apply(
                 [qml.PauliX(0), stateprep(np.array([0, 1]), wires=[0])]

--- a/tests/test_mixed_simulator_device.py
+++ b/tests/test_mixed_simulator_device.py
@@ -149,16 +149,16 @@ class TestApply:
             (qml.BasisState, [0, 0, 1, 0], [1, 0]),
             (qml.BasisState, [0, 0, 1, 0], [1, 0]),
             (qml.BasisState, [0, 0, 0, 1], [1, 1]),
-            (qml.QubitStateVector, [0, 0, 1, 0], [0, 0, 1, 0]),
-            (qml.QubitStateVector, [0, 0, 1, 0], [0, 0, 1, 0]),
-            (qml.QubitStateVector, [0, 0, 0, 1], [0, 0, 0, 1]),
+            (qml.StatePrep, [0, 0, 1, 0], [0, 0, 1, 0]),
+            (qml.StatePrep, [0, 0, 1, 0], [0, 0, 1, 0]),
+            (qml.StatePrep, [0, 0, 0, 1], [0, 0, 0, 1]),
             (
-                qml.QubitStateVector,
+                qml.StatePrep,
                 [1 / math.sqrt(3), 0, 1 / math.sqrt(3), 1 / math.sqrt(3)],
                 [1 / math.sqrt(3), 0, 1 / math.sqrt(3), 1 / math.sqrt(3)],
             ),
             (
-                qml.QubitStateVector,
+                qml.StatePrep,
                 [1 / math.sqrt(3), 0, -1 / math.sqrt(3), 1 / math.sqrt(3)],
                 [1 / math.sqrt(3), 0, -1 / math.sqrt(3), 1 / math.sqrt(3)],
             ),
@@ -438,17 +438,17 @@ class TestApply:
             simulator_device_1_wire.apply([qml.PauliX(0), qml.BasisState(np.array([0]), wires=[0])])
 
     def test_qubit_state_vector_not_at_beginning_error(self, simulator_device_1_wire):
-        """Tests that application of QubitStateVector raises an error if is not
+        """Tests that application of StatePrep raises an error if is not
         the first operation."""
 
         simulator_device_1_wire.reset()
 
         with pytest.raises(
             qml.DeviceError,
-            match="The operation QubitStateVector is only supported at the beginning of a circuit.",
+            match="The operation StatePrep is only supported at the beginning of a circuit.",
         ):
             simulator_device_1_wire.apply(
-                [qml.PauliX(0), qml.QubitStateVector(np.array([0, 1]), wires=[0])]
+                [qml.PauliX(0), qml.StatePrep(np.array([0, 1]), wires=[0])]
             )
 
 
@@ -469,16 +469,16 @@ class TestStatePreparationErrorsNonAnalytic:
             simulator_device_1_wire.apply([qml.BasisState(np.array([0]), wires=[0])])
 
     def test_qubit_state_vector_not_analytic_error(self, simulator_device_1_wire):
-        """Tests that application of QubitStateVector raises an error if the device
+        """Tests that application of StatePrep raises an error if the device
         is not in analytic mode."""
 
         simulator_device_1_wire.reset()
 
         with pytest.raises(
             qml.DeviceError,
-            match="The operation QubitStateVector is only supported in analytic mode.",
+            match="The operation StatePrep is only supported in analytic mode.",
         ):
-            simulator_device_1_wire.apply([qml.QubitStateVector(np.array([0, 1]), wires=[0])])
+            simulator_device_1_wire.apply([qml.StatePrep(np.array([0, 1]), wires=[0])])
 
 
 @pytest.mark.parametrize("shots", [None])
@@ -527,7 +527,7 @@ class TestExpval:
 
         simulator_device_1_wire.reset()
         simulator_device_1_wire.apply(
-            [qml.QubitStateVector(np.array(input), wires=[0])], rotations=op.diagonalizing_gates()
+            [qml.StatePrep(np.array(input), wires=[0])], rotations=op.diagonalizing_gates()
         )
 
         res = simulator_device_1_wire.expval(op)
@@ -556,7 +556,7 @@ class TestExpval:
 
         simulator_device_1_wire.reset()
         simulator_device_1_wire.apply(
-            [qml.QubitStateVector(np.array(input), wires=[0])], rotations=op.diagonalizing_gates()
+            [qml.StatePrep(np.array(input), wires=[0])], rotations=op.diagonalizing_gates()
         )
 
         res = simulator_device_1_wire.expval(op)
@@ -642,7 +642,7 @@ class TestExpval:
 
         simulator_device_2_wires.reset()
         simulator_device_2_wires.apply(
-            [qml.QubitStateVector(np.array(input), wires=[0, 1])],
+            [qml.StatePrep(np.array(input), wires=[0, 1])],
             rotations=op.diagonalizing_gates(),
         )
 
@@ -726,7 +726,7 @@ class TestVar:
 
         simulator_device_1_wire.reset()
         simulator_device_1_wire.apply(
-            [qml.QubitStateVector(np.array(input), wires=[0])],
+            [qml.StatePrep(np.array(input), wires=[0])],
             rotations=op.diagonalizing_gates(),
         )
 
@@ -762,7 +762,7 @@ class TestVar:
 
         simulator_device_1_wire.reset()
         simulator_device_1_wire.apply(
-            [qml.QubitStateVector(np.array(input), wires=[0])],
+            [qml.StatePrep(np.array(input), wires=[0])],
             rotations=op.diagonalizing_gates(),
         )
 
@@ -817,7 +817,7 @@ class TestVar:
 
         simulator_device_2_wires.reset()
         simulator_device_2_wires.apply(
-            [qml.QubitStateVector(np.array(input), wires=[0, 1])],
+            [qml.StatePrep(np.array(input), wires=[0, 1])],
             rotations=op.diagonalizing_gates(),
         )
 

--- a/tests/test_mixed_simulator_device.py
+++ b/tests/test_mixed_simulator_device.py
@@ -464,7 +464,7 @@ class TestStatePreparationErrorsNonAnalytic:
 
         with pytest.raises(
             qml.DeviceError,
-            match="The operation BasisState is only supported in analytic mode.",
+            match="The operations StatePrep and QubitStateVector are only supported in analytic mode.",
         ):
             simulator_device_1_wire.apply([qml.BasisState(np.array([0]), wires=[0])])
 

--- a/tests/test_mixed_simulator_device.py
+++ b/tests/test_mixed_simulator_device.py
@@ -464,7 +464,7 @@ class TestStatePreparationErrorsNonAnalytic:
 
         with pytest.raises(
             qml.DeviceError,
-            match="The operations StatePrep and QubitStateVector are only supported in analytic mode.",
+            match="The operation BasisState are only supported in analytic mode.",
         ):
             simulator_device_1_wire.apply([qml.BasisState(np.array([0]), wires=[0])])
 
@@ -476,7 +476,7 @@ class TestStatePreparationErrorsNonAnalytic:
 
         with pytest.raises(
             qml.DeviceError,
-            match="The operation StatePrep is only supported in analytic mode.",
+            match="The operations StatePrep and QubitStateVector are only supported in analytic mode.",
         ):
             simulator_device_1_wire.apply([qml.StatePrep(np.array([0, 1]), wires=[0])])
 

--- a/tests/test_mixed_simulator_device.py
+++ b/tests/test_mixed_simulator_device.py
@@ -464,7 +464,7 @@ class TestStatePreparationErrorsNonAnalytic:
 
         with pytest.raises(
             qml.DeviceError,
-            match="The operation BasisState are only supported in analytic mode.",
+            match="The operation BasisState is only supported in analytic mode.",
         ):
             simulator_device_1_wire.apply([qml.BasisState(np.array([0]), wires=[0])])
 

--- a/tests/test_mixed_simulator_device.py
+++ b/tests/test_mixed_simulator_device.py
@@ -437,7 +437,8 @@ class TestApply:
         ):
             simulator_device_1_wire.apply([qml.PauliX(0), qml.BasisState(np.array([0]), wires=[0])])
 
-    def test_qubit_state_vector_not_at_beginning_error(self, simulator_device_1_wire):
+    @pytest.mark.parametrize("stateprep", (qml.QubitStateVector, qml.StatePrep))
+    def test_qubit_state_vector_not_at_beginning_error(self, simulator_device_1_wire, stateprep):
         """Tests that application of StatePrep raises an error if is not
         the first operation."""
 
@@ -448,7 +449,7 @@ class TestApply:
             match="The operation StatePrep is only supported at the beginning of a circuit.",
         ):
             simulator_device_1_wire.apply(
-                [qml.PauliX(0), qml.StatePrep(np.array([0, 1]), wires=[0])]
+                [qml.PauliX(0), stateprep(np.array([0, 1]), wires=[0])]
             )
 
 
@@ -468,7 +469,8 @@ class TestStatePreparationErrorsNonAnalytic:
         ):
             simulator_device_1_wire.apply([qml.BasisState(np.array([0]), wires=[0])])
 
-    def test_qubit_state_vector_not_analytic_error(self, simulator_device_1_wire):
+    @pytest.mark.parametrize("stateprep", (qml.QubitStateVector, qml.StatePrep))
+    def test_qubit_state_vector_not_analytic_error(self, simulator_device_1_wire, stateprep):
         """Tests that application of StatePrep raises an error if the device
         is not in analytic mode."""
 
@@ -478,7 +480,7 @@ class TestStatePreparationErrorsNonAnalytic:
             qml.DeviceError,
             match="The operations StatePrep and QubitStateVector are only supported in analytic mode.",
         ):
-            simulator_device_1_wire.apply([qml.StatePrep(np.array([0, 1]), wires=[0])])
+            simulator_device_1_wire.apply([stateprep(np.array([0, 1]), wires=[0])])
 
 
 @pytest.mark.parametrize("shots", [None])

--- a/tests/test_qsim_device.py
+++ b/tests/test_qsim_device.py
@@ -69,7 +69,7 @@ class TestDeviceIntegration:
 
     @pytest.mark.parametrize("shots", [8192, None])
     @pytest.mark.parametrize(
-        "op, params", [(qml.StatePrep, np.array([0, 1])), (qml.BasisState, np.array([1]))]
+        "op, params", [(qml.StatePrep, np.array([0, 1])), (qml.QubitStateVector, np.array([0, 1])), (qml.BasisState, np.array([1]))]
     )
     def test_decomposition(self, shots, op, params, mocker):
         """Test that StatePrep and BasisState are decomposed"""
@@ -103,6 +103,7 @@ class TestDeviceIntegration:
         [
             "StatePrep",
             "BasisState",
+            "QubitStateVector",
             "CRX",
             "CRY",
             "CRZ",

--- a/tests/test_qsim_device.py
+++ b/tests/test_qsim_device.py
@@ -69,10 +69,10 @@ class TestDeviceIntegration:
 
     @pytest.mark.parametrize("shots", [8192, None])
     @pytest.mark.parametrize(
-        "op, params", [(qml.QubitStateVector, np.array([0, 1])), (qml.BasisState, np.array([1]))]
+        "op, params", [(qml.StatePrep, np.array([0, 1])), (qml.BasisState, np.array([1]))]
     )
     def test_decomposition(self, shots, op, params, mocker):
-        """Test that QubitStateVector and BasisState are decomposed"""
+        """Test that StatePrep and BasisState are decomposed"""
 
         dev = qml.device("cirq.qsim", wires=1, shots=shots)
 
@@ -101,7 +101,7 @@ class TestDeviceIntegration:
     @pytest.mark.parametrize(
         "gate",
         [
-            "QubitStateVector",
+            "StatePrep",
             "BasisState",
             "CRX",
             "CRY",

--- a/tests/test_qsimh_device.py
+++ b/tests/test_qsimh_device.py
@@ -60,7 +60,7 @@ class TestDeviceIntegration:
 
     @pytest.mark.parametrize("shots", [8192])
     @pytest.mark.parametrize(
-        "op, params", [(qml.StatePrep, np.array([0, 1])), (qml.BasisState, np.array([1]))]
+        "op, params", [(qml.StatePrep, np.array([0, 1])), (qml.QubitStateVector, np.array([0, 1])), (qml.BasisState, np.array([1]))]
     )
     def test_decomposition(self, shots, op, params, mocker):
         """Test that StatePrep and BasisState are decomposed"""
@@ -93,6 +93,7 @@ class TestDeviceIntegration:
         "gate",
         [
             "StatePrep",
+            "QubitStateVector",
             "BasisState",
             "CRX",
             "CRY",

--- a/tests/test_qsimh_device.py
+++ b/tests/test_qsimh_device.py
@@ -60,10 +60,10 @@ class TestDeviceIntegration:
 
     @pytest.mark.parametrize("shots", [8192])
     @pytest.mark.parametrize(
-        "op, params", [(qml.QubitStateVector, np.array([0, 1])), (qml.BasisState, np.array([1]))]
+        "op, params", [(qml.StatePrep, np.array([0, 1])), (qml.BasisState, np.array([1]))]
     )
     def test_decomposition(self, shots, op, params, mocker):
-        """Test that QubitStateVector and BasisState are decomposed"""
+        """Test that StatePrep and BasisState are decomposed"""
 
         dev = qml.device("cirq.qsimh", wires=1, shots=shots, qsimh_options=qsimh_options)
 
@@ -92,7 +92,7 @@ class TestDeviceIntegration:
     @pytest.mark.parametrize(
         "gate",
         [
-            "QubitStateVector",
+            "StatePrep",
             "BasisState",
             "CRX",
             "CRY",

--- a/tests/test_simulator_device.py
+++ b/tests/test_simulator_device.py
@@ -193,16 +193,16 @@ class TestApply:
             (qml.BasisState, [0, 0, 1, 0], [1, 0]),
             (qml.BasisState, [0, 0, 1, 0], [1, 0]),
             (qml.BasisState, [0, 0, 0, 1], [1, 1]),
-            (qml.QubitStateVector, [0, 0, 1, 0], [0, 0, 1, 0]),
-            (qml.QubitStateVector, [0, 0, 1, 0], [0, 0, 1, 0]),
-            (qml.QubitStateVector, [0, 0, 0, 1], [0, 0, 0, 1]),
+            (qml.StatePrep, [0, 0, 1, 0], [0, 0, 1, 0]),
+            (qml.StatePrep, [0, 0, 1, 0], [0, 0, 1, 0]),
+            (qml.StatePrep, [0, 0, 0, 1], [0, 0, 0, 1]),
             (
-                qml.QubitStateVector,
+                qml.StatePrep,
                 [1 / math.sqrt(3), 0, 1 / math.sqrt(3), 1 / math.sqrt(3)],
                 [1 / math.sqrt(3), 0, 1 / math.sqrt(3), 1 / math.sqrt(3)],
             ),
             (
-                qml.QubitStateVector,
+                qml.StatePrep,
                 [1 / math.sqrt(3), 0, -1 / math.sqrt(3), 1 / math.sqrt(3)],
                 [1 / math.sqrt(3), 0, -1 / math.sqrt(3), 1 / math.sqrt(3)],
             ),
@@ -471,17 +471,17 @@ class TestApply:
             simulator_device_1_wire.apply([qml.PauliX(0), qml.BasisState(np.array([0]), wires=[0])])
 
     def test_qubit_state_vector_not_at_beginning_error(self, simulator_device_1_wire):
-        """Tests that application of QubitStateVector raises an error if is not
+        """Tests that application of StatePrep raises an error if is not
         the first operation."""
 
         simulator_device_1_wire.reset()
 
         with pytest.raises(
             qml.DeviceError,
-            match="The operation QubitStateVector is only supported at the beginning of a circuit.",
+            match="The operation StatePrep is only supported at the beginning of a circuit.",
         ):
             simulator_device_1_wire.apply(
-                [qml.PauliX(0), qml.QubitStateVector(np.array([0, 1]), wires=[0])]
+                [qml.PauliX(0), qml.StatePrep(np.array([0, 1]), wires=[0])]
             )
 
 
@@ -502,16 +502,16 @@ class TestStatePreparationErrorsNonAnalytic:
             simulator_device_1_wire.apply([qml.BasisState(np.array([0]), wires=[0])])
 
     def test_qubit_state_vector_not_analytic_error(self, simulator_device_1_wire):
-        """Tests that application of QubitStateVector raises an error if the device
+        """Tests that application of StatePrep raises an error if the device
         is not in analytic mode."""
 
         simulator_device_1_wire.reset()
 
         with pytest.raises(
             qml.DeviceError,
-            match="The operation QubitStateVector is only supported in analytic mode.",
+            match="The operation StatePrep is only supported in analytic mode.",
         ):
-            simulator_device_1_wire.apply([qml.QubitStateVector(np.array([0, 1]), wires=[0])])
+            simulator_device_1_wire.apply([qml.StatePrep(np.array([0, 1]), wires=[0])])
 
 
 @pytest.mark.parametrize("shots", [None])
@@ -560,7 +560,7 @@ class TestExpval:
 
         simulator_device_1_wire.reset()
         simulator_device_1_wire.apply(
-            [qml.QubitStateVector(np.array(input), wires=[0])], rotations=op.diagonalizing_gates()
+            [qml.StatePrep(np.array(input), wires=[0])], rotations=op.diagonalizing_gates()
         )
 
         res = simulator_device_1_wire.expval(op)
@@ -589,7 +589,7 @@ class TestExpval:
 
         simulator_device_1_wire.reset()
         simulator_device_1_wire.apply(
-            [qml.QubitStateVector(np.array(input), wires=[0])], rotations=op.diagonalizing_gates()
+            [qml.StatePrep(np.array(input), wires=[0])], rotations=op.diagonalizing_gates()
         )
 
         res = simulator_device_1_wire.expval(op)
@@ -675,7 +675,7 @@ class TestExpval:
 
         simulator_device_2_wires.reset()
         simulator_device_2_wires.apply(
-            [qml.QubitStateVector(np.array(input), wires=[0, 1])],
+            [qml.StatePrep(np.array(input), wires=[0, 1])],
             rotations=op.diagonalizing_gates(),
         )
 
@@ -714,7 +714,7 @@ class TestVar:
 
         simulator_device_1_wire.reset()
         simulator_device_1_wire.apply(
-            [qml.QubitStateVector(np.array(input), wires=[0])],
+            [qml.StatePrep(np.array(input), wires=[0])],
             rotations=op.diagonalizing_gates(),
         )
 
@@ -750,7 +750,7 @@ class TestVar:
 
         simulator_device_1_wire.reset()
         simulator_device_1_wire.apply(
-            [qml.QubitStateVector(np.array(input), wires=[0])],
+            [qml.StatePrep(np.array(input), wires=[0])],
             rotations=op.diagonalizing_gates(),
         )
 
@@ -801,7 +801,7 @@ class TestVar:
 
         simulator_device_2_wires.reset()
         simulator_device_2_wires.apply(
-            [qml.QubitStateVector(np.array(input), wires=[0, 1])],
+            [qml.StatePrep(np.array(input), wires=[0, 1])],
             rotations=op.diagonalizing_gates(),
         )
 

--- a/tests/test_simulator_device.py
+++ b/tests/test_simulator_device.py
@@ -479,7 +479,7 @@ class TestApply:
 
         with pytest.raises(
             qml.DeviceError,
-            match="The operation StatePrep is only supported at the beginning of a circuit.",
+            match=f"The operation {stateprep.__name__} is only supported at the beginning of a circuit.",
         ):
             simulator_device_1_wire.apply(
                 [qml.PauliX(0), stateprep(np.array([0, 1]), wires=[0])]

--- a/tests/test_simulator_device.py
+++ b/tests/test_simulator_device.py
@@ -470,7 +470,8 @@ class TestApply:
         ):
             simulator_device_1_wire.apply([qml.PauliX(0), qml.BasisState(np.array([0]), wires=[0])])
 
-    def test_qubit_state_vector_not_at_beginning_error(self, simulator_device_1_wire):
+    @pytest.mark.parametrize("stateprep", (qml.StatePrep, qml.QubitStateVector))
+    def test_qubit_state_vector_not_at_beginning_error(self, simulator_device_1_wire, stateprep):
         """Tests that application of StatePrep raises an error if is not
         the first operation."""
 
@@ -481,7 +482,7 @@ class TestApply:
             match="The operation StatePrep is only supported at the beginning of a circuit.",
         ):
             simulator_device_1_wire.apply(
-                [qml.PauliX(0), qml.StatePrep(np.array([0, 1]), wires=[0])]
+                [qml.PauliX(0), stateprep(np.array([0, 1]), wires=[0])]
             )
 
 
@@ -501,7 +502,8 @@ class TestStatePreparationErrorsNonAnalytic:
         ):
             simulator_device_1_wire.apply([qml.BasisState(np.array([0]), wires=[0])])
 
-    def test_qubit_state_vector_not_analytic_error(self, simulator_device_1_wire):
+    @pytest.mark.parametrize("stateprep", (qml.QubitStateVector, qml.StatePrep))
+    def test_qubit_state_vector_not_analytic_error(self, simulator_device_1_wire, stateprep):
         """Tests that application of StatePrep raises an error if the device
         is not in analytic mode."""
 
@@ -511,7 +513,7 @@ class TestStatePreparationErrorsNonAnalytic:
             qml.DeviceError,
             match="The operations StatePrep and QubitStateVector are only supported in analytic mode.",
         ):
-            simulator_device_1_wire.apply([qml.StatePrep(np.array([0, 1]), wires=[0])])
+            simulator_device_1_wire.apply([stateprep(np.array([0, 1]), wires=[0])])
 
 
 @pytest.mark.parametrize("shots", [None])

--- a/tests/test_simulator_device.py
+++ b/tests/test_simulator_device.py
@@ -509,7 +509,7 @@ class TestStatePreparationErrorsNonAnalytic:
 
         with pytest.raises(
             qml.DeviceError,
-            match="The operation StatePrep is only supported in analytic mode.",
+            match="The operations StatePrep and QubitStateVector are only supported in analytic mode.",
         ):
             simulator_device_1_wire.apply([qml.StatePrep(np.array([0, 1]), wires=[0])])
 


### PR DESCRIPTION
The CI was experiencing some failures: https://github.com/PennyLaneAI/plugin-test-matrix/actions/runs/5930704451/job/16080993219?pr=46

but updating to natively support `StatePrep` as well as `QubitStateVector` seems to fix the problem.