### PR TITLE
remove expval ovverride; allow atol for cirq mixed state simulator test

### DIFF
--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -244,16 +244,6 @@ class MixedStateSimulatorDevice(SimulatorDevice):
         )
         return capabilities
 
-    def expval(self, observable, shot_range=None, bin_size=None):
-        # The simulate_expectation_values from Cirq for mixed states involves
-        # a density matrix check, which does not always pass because the tolerance
-        # is too low. If the error is raised we use the PennyLane function for
-        # expectation value.
-        try:
-            return super().expval(observable, shot_range, bin_size)
-        except ValueError:
-            return qml.QubitDevice.expval(self, observable, shot_range, bin_size)
-
     def _apply_basis_state(self, basis_state_operation):
         super()._apply_basis_state(basis_state_operation)
         self._initial_state = self._convert_to_density_matrix(self._initial_state)

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -244,6 +244,16 @@ class MixedStateSimulatorDevice(SimulatorDevice):
         )
         return capabilities
 
+    def expval(self, observable, shot_range=None, bin_size=None):
+        # The simulate_expectation_values from Cirq for mixed states involves
+        # a density matrix check, which does not always pass because the tolerance
+        # is too low. If the error is raised we use the PennyLane function for
+        # expectation value.
+        try:
+            return super().expval(observable, shot_range, bin_size)
+        except ValueError:
+            return qml.QubitDevice.expval(self, observable, shot_range, bin_size)
+
     def _apply_basis_state(self, basis_state_operation):
         super()._apply_basis_state(basis_state_operation)
         self._initial_state = self._convert_to_density_matrix(self._initial_state)

--- a/tests/test_mixed_simulator_device.py
+++ b/tests/test_mixed_simulator_device.py
@@ -695,7 +695,7 @@ class TestExpval:
             return qml.expval(qml.PauliZ(0))
 
         qnode = qml.QNode(circuit, dev)
-        assert np.allclose(qnode(), 0.0)
+        assert np.allclose(qnode(), 0.0, atol=5e-8)
 
 
 @pytest.mark.parametrize("shots", [None])


### PR DESCRIPTION
With numpy <1.25, the probs are identical (`[0.49999967, 0.49999967]`) before dotting with the eigenvalues so the result is exactly zero. With numpy >=1.25, they are not (`[0.49999964, 0.49999958]`). This slight change is very mysterious to me, but I have confirmed that it appears at [this line](https://github.com/PennyLaneAI/pennylane-cirq/blob/8447c1116355de8390789c2cb7794fa6deab50fd/pennylane_cirq/simulator_device.py#L109-L111). The inputted `self.circuit` is identical, and the outputted result is reliably off. Each value in the state is off by up to 3e-8, and I don't know why (they aren't totally random rounding errors because the difference between old and new states are numbers like `1.00000e-8` or `9.3400000e-9`).

My solution for now is to allow an atol of 5e-8.

EDIT: I've removed the expval override since it's not covered anymore. It was needed with the old numpy - should I pin the minimum, or keep the expval and put a no-cover comment on it?

EDIT 2: I decided to keep the override so we can still use old numpy without issues, and I added a test that forces use of the old one for codecov happiness