### PR TITLE
Fix batch execute with pasqal device

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,7 @@ jobs:
           pl-device-test --device=cirq.simulator --tb=short --skip-ops --analytic=False --shots=20000 --cov=pennylane_cirq --cov-report=xml
           pl-device-test --device=cirq.mixedsimulator --tb=short --skip-ops --analytic=True --cov=pennylane_cirq --cov-report=xml
           pl-device-test --device=cirq.mixedsimulator --tb=short --skip-ops --analytic=False --shots=20000 --cov=pennylane_cirq --cov-report=xml
+          pl-device-test --device=cirq.pasqal --tb=short --skip-ops --analytic=False --shots=20000 --device-kwargs control_radius=2.
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,7 +83,7 @@ jobs:
           pl-device-test --device=cirq.simulator --tb=short --skip-ops --analytic=False --shots=20000 --cov=pennylane_cirq --cov-report=xml
           pl-device-test --device=cirq.mixedsimulator --tb=short --skip-ops --analytic=True --cov=pennylane_cirq --cov-report=xml
           pl-device-test --device=cirq.mixedsimulator --tb=short --skip-ops --analytic=False --shots=20000 --cov=pennylane_cirq --cov-report=xml
-          pl-device-test --device=cirq.pasqal --tb=short --skip-ops --analytic=False --shots=20000 --device-kwargs control_radius=2.
+          pl-device-test --device=cirq.pasqal --tb=short --skip-ops --analytic=False --shots=20000 --device-kwargs control_radius=2. --cov=pennylane_cirq --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 ### Bug fixes 🐛
 
-* Fixes the pasqal device when more than one circuit is executed.
+* Fixes the pasqal device when more than one circuit is executed and adds support
+  for specifying `wires` an iterable of wire labels.
   [(#151)](https://github.com/PennyLaneAI/pennylane-cirq/pull/151)
 
 ### Contributors ✍️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@
 
 ### Bug fixes 🐛
 
+* Fixes the pasqal device when more than one circuit is executed.
+
 ### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
+
+Christina Lee
 
 ---
 # Release 0.32.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Bug fixes 🐛
 
 * Fixes the pasqal device when more than one circuit is executed.
+  [(#151)](https://github.com/PennyLaneAI/pennylane-cirq/pull/151)
 
 ### Contributors ✍️
 

--- a/doc/devices/pasqal.rst
+++ b/doc/devices/pasqal.rst
@@ -17,7 +17,7 @@ the ``ThreeDQubit`` and the notion of a ``control_radius``.
 
 .. code-block:: python
 
-    from cirq.pasqal import ThreeDQubit
+    from cirq_pasqal import ThreeDQubit
     qubits = [ThreeDQubit(x, y, z)
               for x in range(2)
               for y in range(2)

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -207,10 +207,8 @@ class CirqDevice(QubitDevice, abc.ABC):
         # pylint: disable=missing-function-docstring
         super().reset()
 
-        if self.cirq_device:
-            self.circuit = cirq.Circuit(device=self.cirq_device)
-        else:
-            self.circuit = cirq.Circuit()
+        self.circuit = cirq.Circuit()
+
 
     @property
     def observables(self):

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -209,7 +209,6 @@ class CirqDevice(QubitDevice, abc.ABC):
 
         self.circuit = cirq.Circuit()
 
-
     @property
     def observables(self):
         # pylint: disable=missing-function-docstring

--- a/pennylane_cirq/pasqal_device.py
+++ b/pennylane_cirq/pasqal_device.py
@@ -30,7 +30,7 @@ class PasqalDevice(SimulatorDevice):
         shots (int): Number of circuit evaluations/random samples used
             to estimate expectation values of observables. Shots need
             to be >= 1. If ``None``, expecation values are calculated analytically.
-        qubits (List[cirq.ThreeDGridQubit]): A list of Cirq ThreeDGridQubits that are used
+        qubits (List[cirq_pasqal.ThreeDGridQubit]): A list of Cirq ThreeDGridQubits that are used
             as wires. If not specified, the ThreeDGridQubits are put in a linear
             arrangement along the first coordinate axis, separated by a distance of
             ``control_radius / 2``.

--- a/pennylane_cirq/pasqal_device.py
+++ b/pennylane_cirq/pasqal_device.py
@@ -40,12 +40,12 @@ class PasqalDevice(SimulatorDevice):
     short_name = "cirq.pasqal"
 
     def __init__(self, wires, control_radius, shots=None, qubits=None):
+        super().__init__(wires, shots, qubits)
         if not qubits:
             qubits = [
-                cirq_pasqal.ThreeDQubit(wire * float(control_radius) / 2, 0, 0) for wire in range(wires)
+                cirq_pasqal.ThreeDQubit(wire * float(control_radius) / 2, 0, 0) for wire in range(len(self.wires))
             ]
         self.control_radius = float(control_radius)
         if self.control_radius < 0:
             raise ValueError("The control_radius must be a non-negative real number.")
-        super().__init__(wires, shots, qubits)
         self.cirq_device = cirq_pasqal.PasqalVirtualDevice(self.control_radius, qubits)

--- a/pennylane_cirq/pasqal_device.py
+++ b/pennylane_cirq/pasqal_device.py
@@ -40,12 +40,17 @@ class PasqalDevice(SimulatorDevice):
     short_name = "cirq.pasqal"
 
     def __init__(self, wires, control_radius, shots=None, qubits=None):
-        super().__init__(wires, shots, qubits)
+        if isinstance(wires, int):
+            # interpret wires as the number of consecutive wires
+            wires = range(wires)
         if not qubits:
             qubits = [
-                cirq_pasqal.ThreeDQubit(wire * float(control_radius) / 2, 0, 0) for wire in range(len(self.wires))
+                cirq_pasqal.ThreeDQubit(wire * control_radius / 2, 0, 0)
+                for wire in range(len(wires))
             ]
         self.control_radius = float(control_radius)
         if self.control_radius < 0:
             raise ValueError("The control_radius must be a non-negative real number.")
+        super().__init__(wires, shots, qubits)
+
         self.cirq_device = cirq_pasqal.PasqalVirtualDevice(self.control_radius, qubits)

--- a/pennylane_cirq/pasqal_device.py
+++ b/pennylane_cirq/pasqal_device.py
@@ -42,7 +42,7 @@ class PasqalDevice(SimulatorDevice):
     def __init__(self, wires, control_radius, shots=None, qubits=None):
         if not qubits:
             qubits = [
-                cirq_pasqal.ThreeDQubit(wire * control_radius / 2, 0, 0) for wire in range(wires)
+                cirq_pasqal.ThreeDQubit(wire * float(control_radius) / 2, 0, 0) for wire in range(wires)
             ]
         self.control_radius = float(control_radius)
         if self.control_radius < 0:


### PR DESCRIPTION
`cirq.Circuit` no longer has a device argument.

This wasn't caught as the reset method was not being tested for the pasqal device.  This PR also adds a test that will execute multiple circuits.

I also started converting `control_radius` to a float so we can start using `cirq.pasqal` in the automatic test matrix.