### PR TITLE
stop using obs.return type in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Improvements 🛠
 
+* Sample tests have been updated to not use the deprecated `Observable.return_type` property.
+  [(#)]()
+
 ### Breaking changes 💔
 
 ### Deprecations 👋
@@ -15,6 +18,8 @@
 ### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
+
+Matthew Silverman
 
 ---
 # Release 0.33.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Improvements 🛠
 
 * Sample tests have been updated to not use the deprecated `Observable.return_type` property.
-  [(#)]()
+  [(#158)](https://github.com/PennyLaneAI/pennylane-cirq/pull/158)
 
 ### Breaking changes 💔
 

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -50,11 +50,7 @@ class TestSample:
         with mimic_execution_for_sample(dev):
             dev.apply([qml.RX(1.5708, wires=[0])])
 
-        dev._obs_queue = [qml.PauliZ(wires=[0])]
-
-        for idx in range(len(dev._obs_queue)):
-            dev._obs_queue[idx].return_type = qml.measurements.Sample
-
+        dev._obs_queue = [qml.sample(op=qml.PauliZ(wires=[0]))]
         s1 = dev.sample(qml.PauliZ(wires=[0]))
 
         # s1 should only contain 1 and -1
@@ -75,11 +71,7 @@ class TestSample:
                 rotations=qml.Hermitian(A, wires=[0]).diagonalizing_gates(),
             )
 
-        dev._obs_queue = [qml.Hermitian(A, wires=[0])]
-
-        for idx in range(len(dev._obs_queue)):
-            dev._obs_queue[idx].return_type = qml.measurements.Sample
-
+        dev._obs_queue = [qml.sample(op=qml.Hermitian(A, wires=[0]))]
         s1 = dev.sample(qml.Hermitian(A, wires=[0]))
 
         # s1 should only contain the eigenvalues of
@@ -104,8 +96,7 @@ class TestSample:
         with mimic_execution_for_sample(dev):
             dev.apply([qml.RX(theta, wires=[0])])
 
-        dev._obs_queue = [qml.Projector([0], wires=0)]
-        dev._obs_queue[0].return_type = qml.measurements.Sample
+        dev._obs_queue = [qml.sample(op=qml.Projector([0], wires=0))]
         s1 = dev.sample(qml.Projector([0], wires=[0]))
         # s1 should only contain 0 or 1, the eigenvalues of the projector
         assert np.allclose(sorted(list(set(s1))), [0, 1], **tol)
@@ -114,8 +105,7 @@ class TestSample:
             np.var(s1), np.cos(theta / 2) ** 2 - (np.cos(theta / 2) ** 2) ** 2, **tol
         )
 
-        dev._obs_queue = [qml.Projector([1], wires=0)]
-        dev._obs_queue[0].return_type = qml.measurements.Sample
+        dev._obs_queue = [qml.sample(op=qml.Projector([1], wires=0))]
         s1 = dev.sample(qml.Projector([1], wires=[0]))
         assert np.allclose(sorted(list(set(s1))), [0, 1], **tol)
         assert np.allclose(np.mean(s1), np.sin(theta / 2) ** 2, **tol)
@@ -149,10 +139,7 @@ class TestSample:
                 rotations=qml.Hermitian(A, wires=[0, 1]).diagonalizing_gates(),
             )
 
-        dev._obs_queue = [qml.Hermitian(A, wires=[0, 1])]
-
-        for idx in range(len(dev._obs_queue)):
-            dev._obs_queue[idx].return_type = qml.measurements.Sample
+        dev._obs_queue = [qml.sample(op=qml.Hermitian(A, wires=[0, 1]))]
 
         s1 = dev.sample(qml.Hermitian(A, wires=[0, 1]))
 
@@ -189,30 +176,26 @@ class TestSample:
                 ]
             )
 
-        dev._obs_queue = [qml.Projector([0, 0], wires=[0, 1])]
-        dev._obs_queue[0].return_type = qml.measurements.Sample
+        dev._obs_queue = [qml.sample(op=qml.Projector([0, 0], wires=[0, 1]))]
         s1 = dev.sample(qml.Projector([0, 0], wires=[0, 1]))
         # s1 should only contain 0 or 1, the eigenvalues of the projector
         assert np.allclose(sorted(list(set(s1))), [0, 1], **tol)
         expected = (np.cos(theta / 2) * np.cos(theta)) ** 2
         assert np.allclose(np.mean(s1), expected, **tol)
 
-        dev._obs_queue = [qml.Projector([0, 1], wires=[0, 1])]
-        dev._obs_queue[0].return_type = qml.measurements.Sample
+        dev._obs_queue = [qml.sample(op=qml.Projector([0, 1], wires=[0, 1]))]
         s1 = dev.sample(qml.Projector([0, 1], wires=[0, 1]))
         assert np.allclose(sorted(list(set(s1))), [0, 1], **tol)
         expected = (np.cos(theta / 2) * np.sin(theta)) ** 2
         assert np.allclose(np.mean(s1), expected, **tol)
 
-        dev._obs_queue = [qml.Projector([1, 0], wires=[0, 1])]
-        dev._obs_queue[0].return_type = qml.measurements.Sample
+        dev._obs_queue = [qml.sample(op=qml.Projector([1, 0], wires=[0, 1]))]
         s1 = dev.sample(qml.Projector([1, 0], wires=[0, 1]))
         assert np.allclose(sorted(list(set(s1))), [0, 1], **tol)
         expected = (np.sin(theta / 2) * np.sin(theta)) ** 2
         assert np.allclose(np.mean(s1), expected, **tol)
 
-        dev._obs_queue = [qml.Projector([1, 1], wires=[0, 1])]
-        dev._obs_queue[0].return_type = qml.measurements.Sample
+        dev._obs_queue = [qml.sample(op=qml.Projector([1, 1], wires=[0, 1]))]
         s1 = dev.sample(qml.Projector([1, 1], wires=[0, 1]))
         assert np.allclose(sorted(list(set(s1))), [0, 1], **tol)
         expected = (np.sin(theta / 2) * np.cos(theta)) ** 2


### PR DESCRIPTION
`qml._device.Device.sample` now works with `MeasurementProcess` objects, so I'm using those in tests instead to avoid the deprecation warning