### PR TITLE
Fix image urls to point to new image locations

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -66,7 +66,7 @@ Check out these demos to see the PennyLane-Cirq plugin in action:
 
 .. title-card::
     :name: Variationally optimizing measurement protocols
-    :description: <img src="https://pennylane.ai/_images/illustration.png" width="100%" />
+    :description: <img src="https://pennylane.ai/_static/demonstration_assets/quantum_metrology/illustration.png" width="100%" />
     :link: https://pennylane.ai/qml/demos/tutorial_quantum_metrology.html
 
 .. title-card::

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -71,7 +71,7 @@ Check out these demos to see the PennyLane-Cirq plugin in action:
 
 .. title-card::
     :name: Beyond classical computing with qsim
-    :description: <img src="https://pennylane.ai/_images/sycamore.png" width="100%" />
+    :description: <img src="https://pennylane.ai/_static/demonstration_assets/qsim_beyond_classical/sycamore.png" width="100%" />
     :link:  https://pennylane.ai/qml/demos/qsim_beyond_classical.html
 
 .. raw:: html

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -56,7 +56,7 @@ Check out these demos to see the PennyLane-Cirq plugin in action:
 
 .. title-card::
     :name: Quantum Generative Adversarial Networks with Cirq + TensorFlow
-    :description: <img src="https://pennylane.ai/_images/qgan3.png" width="100%" />
+    :description: <img src="https://pennylane.ai/_static/demonstration_assets/QGAN/qgan3.png" width="100%" />
     :link:  https://pennylane.ai/qml/demos/tutorial_QGAN.html
 
 .. title-card::

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -61,7 +61,7 @@ Check out these demos to see the PennyLane-Cirq plugin in action:
 
 .. title-card::
     :name: Quantum computation with neutral atoms
-    :description: <img src="https://pennylane.ai/_images/pasqal_thumbnail.png" width="100%" />
+    :description: <img src="https://pennylane.ai/_static/demonstration_assets/pasqal/pasqal_thumbnail.png" width="100%" />
     :link: https://pennylane.ai/qml/demos/tutorial_pasqal.html
 
 .. title-card::

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -51,7 +51,7 @@ Check out these demos to see the PennyLane-Cirq plugin in action:
 
 .. title-card::
     :name: Optimizing noisy circuits with Cirq
-    :description: <img src="https://pennylane.ai/_images/noisy_circuit_optimization_thumbnail.png" width="100%" />
+    :description: <img src="https://pennylane.ai/_static/demonstration_assets/noisy_circuit_optimization/noisy_circuit_optimization_thumbnail.png" width="100%" />
     :link: https://pennylane.ai/qml/demos/tutorial_noisy_circuit_optimization.html
 
 .. title-card::


### PR DESCRIPTION
Some image links were not working correctly after the QML repo restructuring:
![image](https://github.com/PennyLaneAI/pennylane-cirq/assets/12532113/8dea77aa-ac57-4130-91d4-e7717b6708bf)

This PR fixes these URLs so they point to the right place