### PR TITLE
BugFix: support for Identity on multiple wires

### DIFF
--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -171,7 +171,7 @@ class CirqDevice(QubitDevice, abc.ABC):
         "Hermitian": None,
         # TODO: Consider using qml.utils.decompose_hamiltonian() to support this observable.
         "Prod": None,
-        "Identity": CirqOperation(lambda *args: cirq.IdentityGate(*args)),
+        "Identity": CirqOperation(cirq.IdentityGate),
         "Projector": CirqOperation(lambda: cirq.ProductState.projector),
     }
 


### PR DESCRIPTION
**Context**
`apply` fails with `Identity` on multiple wires because `cirq.I` only accepts a single wire.

**Change**
Replace `cirq.I` with `cirq.IdentityGate` which does allow specifying the number of wires

**Shortcut**
[sc-61681]