### PR TITLE
Fix deprecated import path for `QubitDevice`

### DIFF
--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -37,8 +37,8 @@ from collections import OrderedDict
 import functools
 import operator
 
-import cirq
 import numpy as np
+import cirq
 import pennylane as qml
 from pennylane.devices import QubitDevice
 from pennylane.operation import Tensor

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -40,7 +40,7 @@ import operator
 import cirq
 import numpy as np
 import pennylane as qml
-from pennylane import QubitDevice
+from pennylane.devices import QubitDevice
 from pennylane.operation import Tensor
 from pennylane.ops import Prod
 from pennylane.wires import Wires


### PR DESCRIPTION
pennylane.QubitDevice is deprecated in v0.39, importing QubitDevice from pennylane.devices instead.