### PR TITLE
Replace qml.QubitDevice with qml.devices.QubitDevice

### DIFF
--- a/pennylane_cirq/qsim_device.py
+++ b/pennylane_cirq/qsim_device.py
@@ -151,7 +151,7 @@ class QSimhDevice(SimulatorDevice):
         return capabilities
 
     def expval(self, observable, shot_range=None, bin_size=None):
-        return qml.QubitDevice.expval(self, observable, shot_range, bin_size)
+        return qml.devices.QubitDevice.expval(self, observable, shot_range, bin_size)
 
     def apply(self, operations, **kwargs):
         # pylint: disable=missing-function-docstring

--- a/pennylane_cirq/qsim_device.py
+++ b/pennylane_cirq/qsim_device.py
@@ -15,8 +15,8 @@
 """
 This module provides the ``QSimDevice`` and ``QSimhDevice`` from Cirq.
 """
-import cirq
 import numpy as np
+import cirq
 import pennylane as qml
 
 try:

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -266,7 +266,7 @@ class MixedStateSimulatorDevice(SimulatorDevice):
         try:
             return super().expval(observable, shot_range, bin_size)
         except ValueError:
-            return qml.QubitDevice.expval(self, observable, shot_range, bin_size)
+            return qml.devices.QubitDevice.expval(self, observable, shot_range, bin_size)
 
     def _apply_basis_state(self, basis_state_operation):
         super()._apply_basis_state(basis_state_operation)

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -31,8 +31,8 @@ Classes
 
 ----
 """
-import cirq
 import numpy as np
+import cirq
 import pennylane as qml
 
 from .cirq_device import CirqDevice

--- a/tests/test_mixed_simulator_device.py
+++ b/tests/test_mixed_simulator_device.py
@@ -701,7 +701,7 @@ class TestExpval:
                     qml.apply(gate)
             return qml.expval(qml.PauliZ(0))
 
-        spy = mocker.spy(qml.QubitDevice, "expval")
+        spy = mocker.spy(qml.devices.QubitDevice, "expval")
 
         if use_super:
             mock_simulate = mocker.patch("cirq.DensityMatrixSimulator.simulate_expectation_values")


### PR DESCRIPTION
`pennylane.QubitDevice` has been deprecated as of PennyLane v0.39. This PR ensures that `QubitDevice` is now imported from `pennylane.devices` instead.

This PR is a followup to https://github.com/PennyLaneAI/pennylane-cirq/pull/194 where some of these changes seem to have been overlooked.