### PR TITLE
Delete references to the removed `QubitStateVector` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Breaking changes 💔
 
+* The ``qml.QubitStateVector`` template has been removed. Instead, use :class:`~pennylane.StatePrep`.
+
 ### Deprecations 👋
 
 ### Documentation 📝
@@ -15,6 +17,8 @@
 ### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):
+
+Andrija Paurevic
 
 ---
 # Release 0.39.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking changes 💔
 
 * The ``qml.QubitStateVector`` template has been removed. Instead, use :class:`~pennylane.StatePrep`.
+  [(#203)](https://github.com/PennyLaneAI/pennylane-cirq/pull/203)
 
 ### Deprecations 👋
 

--- a/doc/devices/qsim.rst
+++ b/doc/devices/qsim.rst
@@ -122,7 +122,7 @@ more qubits.
 For state preparation qsim relies on decomposing ``BasisState`` into a set of
 `PauliX
 <https://pennylane.readthedocs.io/en/stable/code/api/pennylane.PauliX.html>`__
-gates and `QubitStateVector
-<https://pennylane.readthedocs.io/en/stable/code/api/pennylane.QubitStateVector.html>`__
+gates and `StatePrep
+<https://pennylane.readthedocs.io/en/stable/code/api/pennylane.StatePrep.html>`__
 via `Möttönen state preparation
 <https://pennylane.readthedocs.io/en/stable/code/api/pennylane.templates.state_preparations.MottonenStatePreparation.html>`__.

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -118,7 +118,6 @@ class CirqDevice(QubitDevice, abc.ABC):
     _base_operation_map = {
         **{f"Pow({k})": v for k, v in _pow_operation_map.items()},
         "BasisState": None,
-        "QubitStateVector": None,
         "StatePrep": None,
         "QubitUnitary": CirqOperation(cirq.MatrixGate),
         "PauliX": CirqOperation(lambda: cirq.X),
@@ -244,7 +243,7 @@ class CirqDevice(QubitDevice, abc.ABC):
         """Apply a state vector preparation.
 
         Args:
-            qubit_state_vector_operation (pennylane.QubitStateVector): the QubitStateVector operation instance that shall be applied
+            qubit_state_vector_operation (pennylane.StatePrep): the StatePrep operation instance that shall be applied
 
         Raises:
             NotImplementedError: when not implemented in the subclass
@@ -277,14 +276,14 @@ class CirqDevice(QubitDevice, abc.ABC):
         rotations = kwargs.pop("rotations", [])
 
         for i, operation in enumerate(operations):
-            if i > 0 and operation.name in {"BasisState", "QubitStateVector", "StatePrep"}:
+            if i > 0 and operation.name in {"BasisState", "StatePrep"}:
                 raise qml.DeviceError(
                     f"The operation {operation.name} is only supported at the beginning of a circuit."
                 )
 
             if operation.name == "BasisState":
                 self._apply_basis_state(operation)
-            elif operation.name in {"StatePrep", "QubitStateVector"}:
+            elif operation.name == "StatePrep":
                 self._apply_qubit_state_vector(operation)
             else:
                 self._apply_operation(operation)

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -243,7 +243,7 @@ class CirqDevice(QubitDevice, abc.ABC):
         """Apply a state vector preparation.
 
         Args:
-            qubit_state_vector_operation (pennylane.StatePrep): the StatePrep operation instance that shall be applied
+            state_prep_operation (pennylane.StatePrep): the StatePrep operation instance that shall be applied
 
         Raises:
             NotImplementedError: when not implemented in the subclass

--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -239,7 +239,7 @@ class CirqDevice(QubitDevice, abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def _apply_qubit_state_vector(self, qubit_state_vector_operation):
+    def _apply_state_prep(self, state_prep_operation):
         """Apply a state vector preparation.
 
         Args:
@@ -284,7 +284,7 @@ class CirqDevice(QubitDevice, abc.ABC):
             if operation.name == "BasisState":
                 self._apply_basis_state(operation)
             elif operation.name == "StatePrep":
-                self._apply_qubit_state_vector(operation)
+                self._apply_state_prep(operation)
             else:
                 self._apply_operation(operation)
 

--- a/pennylane_cirq/qsim_device.py
+++ b/pennylane_cirq/qsim_device.py
@@ -67,7 +67,6 @@ class QSimDevice(SimulatorDevice):
     def operations(self):
         # pylint: disable=missing-function-docstring
         return set(self._base_operation_map) - {
-            "QubitStateVector",
             "StatePrep",
             "BasisState",
             "CRX",
@@ -129,7 +128,6 @@ class QSimhDevice(SimulatorDevice):
     def operations(self):
         # pylint: disable=missing-function-docstring
         return set(self._base_operation_map) - {
-            "QubitStateVector",
             "StatePrep",
             "BasisState",
             "CRX",

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -94,9 +94,7 @@ class SimulatorDevice(CirqDevice):
     def _apply_qubit_state_vector(self, qubit_state_vector_operation):
         # pylint: disable=missing-function-docstring
         if self.shots is not None:
-            raise qml.DeviceError(
-                "The operator StatePrep is only supported in analytic mode."
-            )
+            raise qml.DeviceError("The operator StatePrep is only supported in analytic mode.")
 
         self._initial_state = qubit_state_vector_operation.state_vector(
             wire_order=self.wires

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -91,12 +91,12 @@ class SimulatorDevice(CirqDevice):
 
         self._initial_state = basis_state_operation.state_vector(wire_order=self.wires).flatten()
 
-    def _apply_qubit_state_vector(self, qubit_state_vector_operation):
+    def _apply_state_prep(self, state_prep_operation):
         # pylint: disable=missing-function-docstring
         if self.shots is not None:
             raise qml.DeviceError("The operator StatePrep is only supported in analytic mode.")
 
-        self._initial_state = qubit_state_vector_operation.state_vector(
+        self._initial_state = state_prep_operation.state_vector(
             wire_order=self.wires
         ).flatten()
 
@@ -270,8 +270,8 @@ class MixedStateSimulatorDevice(SimulatorDevice):
         super()._apply_basis_state(basis_state_operation)
         self._initial_state = self._convert_to_density_matrix(self._initial_state)
 
-    def _apply_qubit_state_vector(self, qubit_state_vector_operation):
-        super()._apply_qubit_state_vector(qubit_state_vector_operation)
+    def _apply_state_prep(self, state_prep_operation):
+        super()._apply_state_prep(state_prep_operation)
         self._initial_state = self._convert_to_density_matrix(self._initial_state)
 
     def _convert_to_density_matrix(self, state_vec):

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -95,7 +95,7 @@ class SimulatorDevice(CirqDevice):
         # pylint: disable=missing-function-docstring
         if self.shots is not None:
             raise qml.DeviceError(
-                "The operations StatePrep and QubitStateVector are only supported in analytic mode."
+                "The operator StatePrep is only supported in analytic mode."
             )
 
         self._initial_state = qubit_state_vector_operation.state_vector(

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -96,9 +96,7 @@ class SimulatorDevice(CirqDevice):
         if self.shots is not None:
             raise qml.DeviceError("The operator StatePrep is only supported in analytic mode.")
 
-        self._initial_state = state_prep_operation.state_vector(
-            wire_order=self.wires
-        ).flatten()
+        self._initial_state = state_prep_operation.state_vector(wire_order=self.wires).flatten()
 
     def apply(self, operations, **kwargs):
         # pylint: disable=missing-function-docstring

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -106,7 +106,7 @@ class TestApplyPureState:
         expected[np.ravel_multi_index(state, [2] * 4)] = 1
         assert np.allclose(res, expected, **tol)
 
-    def test_qubit_state_vector(self, init_state, shots, tol):
+    def test_state_prep(self, init_state, shots, tol):
         """Test PauliX application"""
         dev = SimulatorDevice(1, shots=shots)
         state = init_state(1)
@@ -288,7 +288,7 @@ class TestApplyMixedState:
         expected = np.kron(expected, expected.conj()).reshape([16, 16])
         assert np.allclose(res, expected, **tol)
 
-    def test_qubit_state_vector(self, init_state, shots, tol):
+    def test_state_prep(self, init_state, shots, tol):
         """Test PauliX application"""
         dev = MixedStateSimulatorDevice(1, shots=shots)
         state = init_state(1)

--- a/tests/test_mixed_simulator_device.py
+++ b/tests/test_mixed_simulator_device.py
@@ -482,7 +482,7 @@ class TestStatePreparationErrorsNonAnalytic:
 
         with pytest.raises(
             qml.DeviceError,
-            match="The operations StatePrep and QubitStateVector are only supported in analytic mode.",
+            match="The operator StatePrep is only supported in analytic mode.",
         ):
             simulator_device_1_wire.apply([qml.StatePrep(np.array([0, 1]), wires=[0])])
 

--- a/tests/test_mixed_simulator_device.py
+++ b/tests/test_mixed_simulator_device.py
@@ -445,7 +445,7 @@ class TestApply:
         ):
             simulator_device_1_wire.apply([qml.PauliX(0), qml.BasisState(np.array([0]), wires=[0])])
 
-    def test_qubit_state_vector_not_at_beginning_error(self, simulator_device_1_wire):
+    def test_state_prep_not_at_beginning_error(self, simulator_device_1_wire):
         """Tests that application of StatePrep raises an error if is not
         the first operation."""
 
@@ -474,7 +474,7 @@ class TestStatePreparationErrorsNonAnalytic:
         ):
             simulator_device_1_wire.apply([qml.BasisState(np.array([0]), wires=[0])])
 
-    def test_qubit_state_vector_not_analytic_error(self, simulator_device_1_wire):
+    def test_state_prep_not_analytic_error(self, simulator_device_1_wire):
         """Tests that application of StatePrep raises an error if the device
         is not in analytic mode."""
 

--- a/tests/test_simulator_device.py
+++ b/tests/test_simulator_device.py
@@ -508,7 +508,7 @@ class TestStatePreparationErrorsNonAnalytic:
 
         with pytest.raises(
             qml.DeviceError,
-            match="The operations StatePrep and QubitStateVector are only supported in analytic mode.",
+            match="The operator StatePrep is only supported in analytic mode.",
         ):
             simulator_device_1_wire.apply([qml.StatePrep(np.array([0, 1]), wires=[0])])
 

--- a/tests/test_simulator_device.py
+++ b/tests/test_simulator_device.py
@@ -471,7 +471,7 @@ class TestApply:
         ):
             simulator_device_1_wire.apply([qml.PauliX(0), qml.BasisState(np.array([0]), wires=[0])])
 
-    def test_qubit_state_vector_not_at_beginning_error(self, simulator_device_1_wire):
+    def test_state_prep_not_at_beginning_error(self, simulator_device_1_wire):
         """Tests that application of StatePrep raises an error if is not
         the first operation."""
 
@@ -500,7 +500,7 @@ class TestStatePreparationErrorsNonAnalytic:
         ):
             simulator_device_1_wire.apply([qml.BasisState(np.array([0]), wires=[0])])
 
-    def test_qubit_state_vector_not_analytic_error(self, simulator_device_1_wire):
+    def test_state_prep_not_analytic_error(self, simulator_device_1_wire):
         """Tests that application of StatePrep raises an error if the device
         is not in analytic mode."""
 


### PR DESCRIPTION
**Context:**

Completing the deprecation cycle of `QubitStateVector` (see https://github.com/PennyLaneAI/pennylane/pull/6525)

**Description of the Change:**

Removed all references to the deprecated source code.

[sc-77482]