### PR TITLE
Post-release version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# Release 0.41.0-dev
+
+### New features since last release
+
+### Improvements 🛠
+
+### Breaking changes 💔
+
+### Deprecations 👋
+
+### Documentation 📝
+
+### Bug fixes 🐛
+
+### Contributors ✍️
+
+This release contains contributions from (in alphabetical order):
+
+---
 # Release 0.40.0
 
 ### Breaking changes 💔

--- a/pennylane_cirq/_version.py
+++ b/pennylane_cirq/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0"
+__version__ = "0.41.0-dev"


### PR DESCRIPTION
Post-release version bump.

**DO NOT MERGE**

It should be merged *after* the plugin has been released.