### PR TITLE
Updating `setuptools`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools
+          python -m pip install --upgrade pip setuptools>=75.8.1
           pip install -r requirements-ci.txt
           pip install qsimcirq
           pip install --upgrade git+https://github.com/PennyLaneAI/pennylane.git#egg=pennylane
@@ -38,7 +38,7 @@ jobs:
       - name: Install Plugin
         run: |
           python setup.py bdist_wheel
-          pip install dist/PennyLane*.whl
+          pip install dist/pennylane*.whl
 
       - name: Run tests
         run: python -m pytest tests --cov=pennylane_cirq --cov-report=term-missing --cov-report=xml -p no:warnings --tb=native
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools
+          python -m pip install --upgrade pip setuptools>=75.8.1
           pip install -r requirements-ci.txt
           pip install qsimcirq
           pip install --upgrade git+https://github.com/PennyLaneAI/pennylane.git#egg=pennylane
@@ -78,7 +78,7 @@ jobs:
       - name: Install Plugin
         run: |
           python setup.py bdist_wheel
-          pip install dist/PennyLane*.whl
+          pip install dist/pennylane*.whl
 
       - name: Run tests
         run: |

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -16,9 +16,9 @@ jobs:
 
       - name: Build and install Plugin
         run: |
-          python -m pip install --upgrade pip wheel
+          python -m pip install --upgrade pip wheel setuptools>=75.8.1
           python setup.py bdist_wheel
-          pip install dist/PennyLane*.whl
+          pip install dist/pennylane*.whl
 
       - name: Install test dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 ### Bug fixes 🐛
 
+### Internal changes
+
+* Pinning `setuptools` in the CI to update how the plugin is installed.
+  [(#208)](https://github.com/PennyLaneAI/pennylane-cirq/pull/208)
+
 ### Contributors ✍️
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane_cirq/_version.py
+++ b/pennylane_cirq/_version.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Version information.
-   Version number (major.minor.patch[-label])
+Version number (major.minor.patch[-label])
 """
 
 __version__ = "0.41.0-dev"


### PR DESCRIPTION
**Context:**
`setuptools` has had a release recently that normalizes package names:

References:
- pypa/setuptools#4766
- https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization

**Description of the Change:**
Due setuptools 75.8.0 and 75.8.1 outputting completely different package names, we cannot support both, so CI now "pins" to >=75.8.1.

**Benefits:**
Fix CI failures.

[sc-85704]