### PR TITLE
Updating Python version to 3.11 in `upload` workflow

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Build and install Plugin
         run: |


### PR DESCRIPTION
`pip install cirq` is broken for Python3.10 due to the Rigetti dependency having issues with the CRC of the compiled module.

Therefore, we switch from `Python 3.10` to `Python 3.11` in the `upload` workflow, otherwise we'll likely have issues with the upcoming release of this plugin.

[sc-85836]