### PR TITLE
Bump PL unpinning NP

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
           python -m pip install --upgrade pip setuptools>=75.8.1
           pip install -r requirements-ci.txt
           pip install qsimcirq
-          pip install --upgrade git+https://github.com/PennyLaneAI/pennylane.git#egg=pennylane
+          pip install --upgrade git+https://github.com/PennyLaneAI/pennylane.git@proto/numpy-2.1#egg=pennylane
           pip install wheel pytest pytest-cov pytest-mock --upgrade
 
       - name: Install Plugin


### PR DESCRIPTION
PL is about to unpinning numpy.
`cirq` used to be super old and might contain some code incompatible. We would like to test with CI running.