### PR TITLE
use new `pennylane.exceptions` module rather than top-level import

### DIFF
--- a/pennylane_cirq/cirq_device.py
+++ b/pennylane_cirq/cirq_device.py
@@ -86,7 +86,7 @@ class CirqDevice(QubitDevice, abc.ABC):
 
         if qubits:
             if num_wires != len(qubits):
-                raise qml.DeviceError(
+                raise qml.exceptions.DeviceError(
                     f"The number of given qubits and the specified number of wires have to match. Got {wires} wires and {len(qubits)} qubits."
                 )
         else:
@@ -275,7 +275,7 @@ class CirqDevice(QubitDevice, abc.ABC):
 
         for i, operation in enumerate(operations):
             if i > 0 and operation.name in {"BasisState", "StatePrep"}:
-                raise qml.DeviceError(
+                raise qml.exceptions.DeviceError(
                     f"The operation {operation.name} is only supported at the beginning of a circuit."
                 )
 

--- a/pennylane_cirq/cirq_operation.py
+++ b/pennylane_cirq/cirq_operation.py
@@ -73,6 +73,8 @@ class CirqOperation:
             *qubits (Cirq:Qid): the qubits on which the Cirq gates should be performed.
         """
         if not self.parametrized_cirq_gates:
-            raise qml.DeviceError("CirqOperation must be parametrized before it can be applied.")
+            raise qml.exceptions.DeviceError(
+                "CirqOperation must be parametrized before it can be applied."
+            )
 
         return (parametrized_gate(*qubits) for parametrized_gate in self.parametrized_cirq_gates)

--- a/pennylane_cirq/simulator_device.py
+++ b/pennylane_cirq/simulator_device.py
@@ -87,14 +87,18 @@ class SimulatorDevice(CirqDevice):
     def _apply_basis_state(self, basis_state_operation):
         # pylint: disable=missing-function-docstring
         if self.shots is not None:
-            raise qml.DeviceError("The operation BasisState is only supported in analytic mode.")
+            raise qml.exceptions.DeviceError(
+                "The operation BasisState is only supported in analytic mode."
+            )
 
         self._initial_state = basis_state_operation.state_vector(wire_order=self.wires).flatten()
 
     def _apply_state_prep(self, state_prep_operation):
         # pylint: disable=missing-function-docstring
         if self.shots is not None:
-            raise qml.DeviceError("The operator StatePrep is only supported in analytic mode.")
+            raise qml.exceptions.DeviceError(
+                "The operator StatePrep is only supported in analytic mode."
+            )
 
         self._initial_state = state_prep_operation.state_vector(wire_order=self.wires).flatten()
 

--- a/tests/test_cirq_device.py
+++ b/tests/test_cirq_device.py
@@ -91,7 +91,7 @@ class TestCirqDeviceInit:
         ]
 
         with pytest.raises(
-            qml.DeviceError,
+            qml.exceptions.DeviceError,
             match="The number of given qubits and the specified number of wires have to match",
         ):
             dev = CirqDevice(3, 100, qubits=qubits)

--- a/tests/test_cirq_operation.py
+++ b/tests/test_cirq_operation.py
@@ -75,7 +75,7 @@ class TestCirqOperation:
         qubit = cirq.LineQubit(1)
 
         with pytest.raises(
-            qml.DeviceError,
+            qml.exceptions.DeviceError,
             match="CirqOperation must be parametrized before it can be applied.",
         ):
             operation.apply(qubit)

--- a/tests/test_mixed_simulator_device.py
+++ b/tests/test_mixed_simulator_device.py
@@ -440,7 +440,7 @@ class TestApply:
         simulator_device_1_wire.reset()
 
         with pytest.raises(
-            qml.DeviceError,
+            qml.exceptions.DeviceError,
             match="The operation BasisState is only supported at the beginning of a circuit.",
         ):
             simulator_device_1_wire.apply([qml.PauliX(0), qml.BasisState(np.array([0]), wires=[0])])
@@ -452,7 +452,7 @@ class TestApply:
         simulator_device_1_wire.reset()
 
         with pytest.raises(
-            qml.DeviceError,
+            qml.exceptions.DeviceError,
             match=f"The operation StatePrep is only supported at the beginning of a circuit.",
         ):
             simulator_device_1_wire.apply([qml.PauliX(0), qml.StatePrep(np.array([0, 1]), wires=[0])])
@@ -469,7 +469,7 @@ class TestStatePreparationErrorsNonAnalytic:
         simulator_device_1_wire.reset()
 
         with pytest.raises(
-            qml.DeviceError,
+            qml.exceptions.DeviceError,
             match="The operation BasisState is only supported in analytic mode.",
         ):
             simulator_device_1_wire.apply([qml.BasisState(np.array([0]), wires=[0])])
@@ -481,7 +481,7 @@ class TestStatePreparationErrorsNonAnalytic:
         simulator_device_1_wire.reset()
 
         with pytest.raises(
-            qml.DeviceError,
+            qml.exceptions.DeviceError,
             match="The operator StatePrep is only supported in analytic mode.",
         ):
             simulator_device_1_wire.apply([qml.StatePrep(np.array([0, 1]), wires=[0])])

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -198,7 +198,7 @@ class TestNoShotSample:
         """Test that a device with shot=None raises an error when sampling"""
         dev = device(1)
 
-        with pytest.raises(qml.QuantumFunctionError):
+        with pytest.raises(qml.exceptions.QuantumFunctionError):
             with mimic_execution_for_sample(dev):
                 dev.apply([qml.RX(1.5708, wires=[0])])
 

--- a/tests/test_simulator_device.py
+++ b/tests/test_simulator_device.py
@@ -466,7 +466,7 @@ class TestApply:
         simulator_device_1_wire.reset()
 
         with pytest.raises(
-            qml.DeviceError,
+            qml.exceptions.DeviceError,
             match="The operation BasisState is only supported at the beginning of a circuit.",
         ):
             simulator_device_1_wire.apply([qml.PauliX(0), qml.BasisState(np.array([0]), wires=[0])])
@@ -478,10 +478,12 @@ class TestApply:
         simulator_device_1_wire.reset()
 
         with pytest.raises(
-            qml.DeviceError,
+            qml.exceptions.DeviceError,
             match=f"The operation StatePrep is only supported at the beginning of a circuit.",
         ):
-            simulator_device_1_wire.apply([qml.PauliX(0), qml.StatePrep(np.array([0, 1]), wires=[0])])
+            simulator_device_1_wire.apply(
+                [qml.PauliX(0), qml.StatePrep(np.array([0, 1]), wires=[0])]
+            )
 
 
 @pytest.mark.parametrize("shots", [1000])
@@ -495,7 +497,7 @@ class TestStatePreparationErrorsNonAnalytic:
         simulator_device_1_wire.reset()
 
         with pytest.raises(
-            qml.DeviceError,
+            qml.exceptions.DeviceError,
             match="The operation BasisState is only supported in analytic mode.",
         ):
             simulator_device_1_wire.apply([qml.BasisState(np.array([0]), wires=[0])])
@@ -507,7 +509,7 @@ class TestStatePreparationErrorsNonAnalytic:
         simulator_device_1_wire.reset()
 
         with pytest.raises(
-            qml.DeviceError,
+            qml.exceptions.DeviceError,
             match="The operator StatePrep is only supported in analytic mode.",
         ):
             simulator_device_1_wire.apply([qml.StatePrep(np.array([0, 1]), wires=[0])])


### PR DESCRIPTION
**Context:**

https://github.com/PennyLaneAI/pennylane/pull/7205 adds the new `exceptions` module.

**Description of the Change:**

Update to use that new module rather than top level imports.

**Benefits:** Should not depend on top-level imports.

**Possible Drawbacks:** None

[sc-88954]