### PR TITLE
Use `set_shots` in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Internal changes ⚙️
 
 * `conftest.py` has a new `device_none_shots` fixture for testing qnodes using new device API.
+  [(#226)](https://github.com/PennyLaneAI/pennylane-cirq/pull/226)
 
 ### Documentation 📝
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Internal changes ⚙️
 
-* `conftest.py` has a new `device_none_shots` fixture for testing qnodes using new device API.
+* `conftest.py` has a new `device_analytic` fixture for testing qnodes using new device API.
   [(#226)](https://github.com/PennyLaneAI/pennylane-cirq/pull/226)
 
 ### Documentation 📝

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 ### Deprecations 👋
 
+### Internal changes ⚙️
+
+* `conftest.py` has a new `device_none_shots` fixture for testing qnodes using new device API.
+
 ### Documentation 📝
 
 ### Bug fixes 🐛
@@ -19,6 +23,7 @@
 
 This release contains contributions from (in alphabetical order):
 
+Yushao Chen,
 Andrija Paurevic.
 
 ---

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,7 @@ def device_analytic(request):
     device = request.param
 
     def _device(n):
-            return device(wires=n, shots=None)
+            return device(wires=n)
+
 
     return _device

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,17 +96,21 @@ def init_state(scope="session"):
 
 @pytest.fixture(params=analytic_devices + hw_devices)
 def device(request, shots):
-    """Fixture to initialize and return a PennyLane device"""
+    """Fixture to initialize and return a PennyLane device with shots"""
     device = request.param
 
-    if device in analytic_devices:
-
-        def _device(n):
+    def _device(n):
             return device(wires=n, shots=shots)
 
-    elif device in hw_devices:
+    return _device
 
-        def _device(n):
-            return device(wires=n, shots=shots)
+
+@pytest.fixture(params=analytic_devices + hw_devices)
+def device_none_shots(request):
+    """Fixture to initialize and return a PennyLane device without shots"""
+    device = request.param
+
+    def _device(n):
+            return device(wires=n, shots=None)
 
     return _device

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,7 +106,7 @@ def device(request, shots):
 
 
 @pytest.fixture(params=analytic_devices + hw_devices)
-def device_none_shots(request):
+def device_analytic(request):
     """Fixture to initialize and return a PennyLane device without shots"""
     device = request.param
 

--- a/tests/test_expval.py
+++ b/tests/test_expval.py
@@ -27,12 +27,12 @@ np.random.seed(42)
 class TestExpval:
     """Test expectation values"""
 
-    def test_identity_expectation(self, device_none_shots, shots, tol):
+    def test_identity_expectation(self, device_analytic, shots, tol):
         """Test that identity expectation value (i.e. the trace) is 1"""
         theta = 0.432
         phi = 0.123
 
-        dev = device_none_shots(2)
+        dev = device_analytic(2)
 
         @qml.set_shots(shots)
         @qml.qnode(dev)
@@ -54,12 +54,12 @@ class TestExpval:
 
         assert np.allclose(res, np.array([1, 1]), **tol)
 
-    def test_pauliz_expectation(self, device_none_shots, shots, tol):
+    def test_pauliz_expectation(self, device_analytic, shots, tol):
         """Test that PauliZ expectation value is correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = device_none_shots(2)
+        dev = device_analytic(2)
 
         @qml.set_shots(shots)
         @qml.qnode(dev)
@@ -81,12 +81,12 @@ class TestExpval:
 
         assert np.allclose(res, np.array([np.cos(theta), np.cos(theta) * np.cos(phi)]), **tol)
 
-    def test_paulix_expectation(self, device_none_shots, shots, tol):
+    def test_paulix_expectation(self, device_analytic, shots, tol):
         """Test that PauliX expectation value is correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = device_none_shots(2)
+        dev = device_analytic(2)
 
         @qml.set_shots(shots)
         @qml.qnode(dev)
@@ -107,12 +107,12 @@ class TestExpval:
         res = [circuit0(phi, theta), circuit1(phi, theta)]
         assert np.allclose(res, np.array([np.sin(theta) * np.sin(phi), np.sin(phi)]), **tol)
 
-    def test_pauliy_expectation(self, device_none_shots, shots, tol):
+    def test_pauliy_expectation(self, device_analytic, shots, tol):
         """Test that PauliY expectation value is correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = device_none_shots(2)
+        dev = device_analytic(2)
         O = qml.PauliY
 
         @qml.set_shots(shots)
@@ -134,12 +134,12 @@ class TestExpval:
         res = [circuit0(phi, theta), circuit1(phi, theta)]
         assert np.allclose(res, np.array([0, -(np.cos(theta)) * np.sin(phi)]), **tol)
 
-    def test_hadamard_expectation(self, device_none_shots, shots, tol):
+    def test_hadamard_expectation(self, device_analytic, shots, tol):
         """Test that Hadamard expectation value is correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = device_none_shots(2)
+        dev = device_analytic(2)
 
         @qml.set_shots(shots)
         @qml.qnode(dev)
@@ -166,12 +166,12 @@ class TestExpval:
         ) / np.sqrt(2)
         assert np.allclose(res, expected, **tol)
 
-    def test_hermitian_expectation(self, device_none_shots, shots, tol):
+    def test_hermitian_expectation(self, device_analytic, shots, tol):
         """Test that arbitrary Hermitian expectation values are correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = device_none_shots(2)
+        dev = device_analytic(2)
 
         @qml.set_shots(shots)
         @qml.qnode(dev)
@@ -200,12 +200,12 @@ class TestExpval:
 
         assert np.allclose(res, expected, **tol)
 
-    def test_multi_mode_hermitian_expectation(self, device_none_shots, shots, tol):
+    def test_multi_mode_hermitian_expectation(self, device_analytic, shots, tol):
         """Test that arbitrary multi-mode Hermitian expectation values are correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = device_none_shots(2)
+        dev = device_analytic(2)
 
         @qml.set_shots(shots)
         @qml.qnode(dev)
@@ -228,12 +228,12 @@ class TestExpval:
 
         assert np.allclose(res, expected, **tol)
 
-    def test_projector_expectation(self, device_none_shots, shots, tol):
+    def test_projector_expectation(self, device_analytic, shots, tol):
         """Test that arbitrary Projector expectation values are correct"""
         theta = 0.732
         phi = 0.523
 
-        dev = device_none_shots(2)
+        dev = device_analytic(2)
 
         @qml.set_shots(shots)
         @qml.qnode(dev)
@@ -292,13 +292,13 @@ class TestExpval:
 class TestTensorExpval:
     """Test tensor expectation values"""
 
-    def test_paulix_pauliy(self, device_none_shots, shots, tol):
+    def test_paulix_pauliy(self, device_analytic, shots, tol):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
         theta = 0.432
         phi = 0.123
         varphi = -0.543
 
-        dev = device_none_shots(3)
+        dev = device_analytic(3)
 
         @qml.set_shots(shots)
         @qml.qnode(dev)
@@ -315,13 +315,13 @@ class TestTensorExpval:
 
         assert np.allclose(res, expected, **tol)
 
-    def test_pauliz_hadamard(self, device_none_shots, shots, tol):
+    def test_pauliz_hadamard(self, device_analytic, shots, tol):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
         theta = 0.432
         phi = 0.123
         varphi = -0.543
 
-        dev = device_none_shots(3)
+        dev = device_analytic(3)
 
         @qml.set_shots(shots)
         @qml.qnode(dev)
@@ -340,13 +340,13 @@ class TestTensorExpval:
 
         assert np.allclose(res, expected, **tol)
 
-    def test_hermitian(self, device_none_shots, shots, tol):
+    def test_hermitian(self, device_analytic, shots, tol):
         """Test that a tensor product involving qml.Hermitian works correctly"""
         theta = 0.432
         phi = 0.123
         varphi = -0.543
 
-        dev = device_none_shots(3)
+        dev = device_analytic(3)
 
         A = np.array(
             [
@@ -377,13 +377,13 @@ class TestTensorExpval:
 
         assert np.allclose(res, expected, **tol)
 
-    def test_projector(self, device_none_shots, shots, tol):
+    def test_projector(self, device_analytic, shots, tol):
         """Test that a tensor product involving qml.Projector works correctly"""
         theta = 0.732
         phi = 0.523
         varphi = -0.543
 
-        dev = device_none_shots(3)
+        dev = device_analytic(3)
 
         @qml.set_shots(shots)
         @qml.qnode(dev)

--- a/tests/test_expval.py
+++ b/tests/test_expval.py
@@ -27,13 +27,14 @@ np.random.seed(42)
 class TestExpval:
     """Test expectation values"""
 
-    def test_identity_expectation(self, device, shots, tol):
+    def test_identity_expectation(self, device_none_shots, shots, tol):
         """Test that identity expectation value (i.e. the trace) is 1"""
         theta = 0.432
         phi = 0.123
 
-        dev = device(2)
+        dev = device_none_shots(2)
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit0(phi, theta):
             qml.RX(theta, wires=[0])
@@ -41,6 +42,7 @@ class TestExpval:
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.Identity(wires=[0]))
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit1(phi, theta):
             qml.RX(theta, wires=[0])
@@ -52,13 +54,14 @@ class TestExpval:
 
         assert np.allclose(res, np.array([1, 1]), **tol)
 
-    def test_pauliz_expectation(self, device, shots, tol):
+    def test_pauliz_expectation(self, device_none_shots, shots, tol):
         """Test that PauliZ expectation value is correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = device(2)
+        dev = device_none_shots(2)
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit0(phi, theta):
             qml.RX(theta, wires=[0])
@@ -66,6 +69,7 @@ class TestExpval:
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliZ(wires=[0]))
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit1(phi, theta):
             qml.RX(theta, wires=[0])
@@ -77,13 +81,14 @@ class TestExpval:
 
         assert np.allclose(res, np.array([np.cos(theta), np.cos(theta) * np.cos(phi)]), **tol)
 
-    def test_paulix_expectation(self, device, shots, tol):
+    def test_paulix_expectation(self, device_none_shots, shots, tol):
         """Test that PauliX expectation value is correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = device(2)
+        dev = device_none_shots(2)
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit0(phi, theta):
             qml.RY(theta, wires=[0])
@@ -91,6 +96,7 @@ class TestExpval:
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliX(wires=[0]))
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit1(phi, theta):
             qml.RY(theta, wires=[0])
@@ -101,14 +107,15 @@ class TestExpval:
         res = [circuit0(phi, theta), circuit1(phi, theta)]
         assert np.allclose(res, np.array([np.sin(theta) * np.sin(phi), np.sin(phi)]), **tol)
 
-    def test_pauliy_expectation(self, device, shots, tol):
+    def test_pauliy_expectation(self, device_none_shots, shots, tol):
         """Test that PauliY expectation value is correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = device(2)
+        dev = device_none_shots(2)
         O = qml.PauliY
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit0(phi, theta):
             qml.RX(theta, wires=[0])
@@ -116,6 +123,7 @@ class TestExpval:
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.PauliY(wires=[0]))
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit1(phi, theta):
             qml.RX(theta, wires=[0])
@@ -126,13 +134,14 @@ class TestExpval:
         res = [circuit0(phi, theta), circuit1(phi, theta)]
         assert np.allclose(res, np.array([0, -(np.cos(theta)) * np.sin(phi)]), **tol)
 
-    def test_hadamard_expectation(self, device, shots, tol):
+    def test_hadamard_expectation(self, device_none_shots, shots, tol):
         """Test that Hadamard expectation value is correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = device(2)
+        dev = device_none_shots(2)
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit0(phi, theta):
             qml.RY(theta, wires=[0])
@@ -140,6 +149,7 @@ class TestExpval:
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.Hadamard(wires=[0]))
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit1(phi, theta):
             qml.RY(theta, wires=[0])
@@ -156,13 +166,14 @@ class TestExpval:
         ) / np.sqrt(2)
         assert np.allclose(res, expected, **tol)
 
-    def test_hermitian_expectation(self, device, shots, tol):
+    def test_hermitian_expectation(self, device_none_shots, shots, tol):
         """Test that arbitrary Hermitian expectation values are correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = device(2)
+        dev = device_none_shots(2)
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit0(phi, theta):
             qml.RY(theta, wires=[0])
@@ -170,6 +181,7 @@ class TestExpval:
             qml.CNOT(wires=[0, 1])
             return qml.expval(qml.Hermitian(A, wires=[0]))
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit1(phi, theta):
             qml.RY(theta, wires=[0])
@@ -188,13 +200,14 @@ class TestExpval:
 
         assert np.allclose(res, expected, **tol)
 
-    def test_multi_mode_hermitian_expectation(self, device, shots, tol):
+    def test_multi_mode_hermitian_expectation(self, device_none_shots, shots, tol):
         """Test that arbitrary multi-mode Hermitian expectation values are correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = device(2)
+        dev = device_none_shots(2)
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit(phi, theta):
             qml.RY(theta, wires=[0])
@@ -215,13 +228,14 @@ class TestExpval:
 
         assert np.allclose(res, expected, **tol)
 
-    def test_projector_expectation(self, device, shots, tol):
+    def test_projector_expectation(self, device_none_shots, shots, tol):
         """Test that arbitrary Projector expectation values are correct"""
         theta = 0.732
         phi = 0.523
 
-        dev = device(2)
+        dev = device_none_shots(2)
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit(phi, theta):
             qml.RY(theta, wires=[0])
@@ -234,6 +248,7 @@ class TestExpval:
 
         assert np.allclose(res, expected, **tol)
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit(phi, theta):
             qml.RY(theta, wires=[0])
@@ -246,6 +261,7 @@ class TestExpval:
 
         assert np.allclose(res, expected, **tol)
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit(phi, theta):
             qml.RY(theta, wires=[0])
@@ -258,6 +274,7 @@ class TestExpval:
         expected = (np.sin(phi / 2) * np.sin(theta / 2)) ** 2
         assert np.allclose(res, expected, **tol)
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit(phi, theta):
             qml.RY(theta, wires=[0])
@@ -275,14 +292,15 @@ class TestExpval:
 class TestTensorExpval:
     """Test tensor expectation values"""
 
-    def test_paulix_pauliy(self, device, shots, tol):
+    def test_paulix_pauliy(self, device_none_shots, shots, tol):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
         theta = 0.432
         phi = 0.123
         varphi = -0.543
 
-        dev = device(3)
+        dev = device_none_shots(3)
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit(theta, phi, varphi):
             qml.RX(theta, wires=[0])
@@ -297,14 +315,15 @@ class TestTensorExpval:
 
         assert np.allclose(res, expected, **tol)
 
-    def test_pauliz_hadamard(self, device, shots, tol):
+    def test_pauliz_hadamard(self, device_none_shots, shots, tol):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
         theta = 0.432
         phi = 0.123
         varphi = -0.543
 
-        dev = device(3)
+        dev = device_none_shots(3)
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit(theta, phi, varphi):
             qml.RX(theta, wires=[0])
@@ -321,13 +340,13 @@ class TestTensorExpval:
 
         assert np.allclose(res, expected, **tol)
 
-    def test_hermitian(self, device, shots, tol):
+    def test_hermitian(self, device_none_shots, shots, tol):
         """Test that a tensor product involving qml.Hermitian works correctly"""
         theta = 0.432
         phi = 0.123
         varphi = -0.543
 
-        dev = device(3)
+        dev = device_none_shots(3)
 
         A = np.array(
             [
@@ -338,6 +357,7 @@ class TestTensorExpval:
             ]
         )
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit(theta, phi, varphi):
             qml.RX(theta, wires=[0])
@@ -357,14 +377,15 @@ class TestTensorExpval:
 
         assert np.allclose(res, expected, **tol)
 
-    def test_projector(self, device, shots, tol):
+    def test_projector(self, device_none_shots, shots, tol):
         """Test that a tensor product involving qml.Projector works correctly"""
         theta = 0.732
         phi = 0.523
         varphi = -0.543
 
-        dev = device(3)
+        dev = device_none_shots(3)
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit(theta, phi, varphi):
             qml.RX(theta, wires=[0])
@@ -380,6 +401,7 @@ class TestTensorExpval:
         ) ** 2
         assert np.allclose(res, expected, **tol)
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit(theta, phi, varphi):
             qml.RX(theta, wires=[0])
@@ -395,6 +417,7 @@ class TestTensorExpval:
         ) ** 2
         assert np.allclose(res, expected, **tol)
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit(theta, phi, varphi):
             qml.RX(theta, wires=[0])
@@ -410,6 +433,7 @@ class TestTensorExpval:
         ) ** 2
         assert np.allclose(res, expected, **tol)
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit(theta, phi, varphi):
             qml.RX(theta, wires=[0])

--- a/tests/test_mixed_simulator_device.py
+++ b/tests/test_mixed_simulator_device.py
@@ -813,8 +813,9 @@ class TestVarEstimate:
     def test_var_estimate(self):
         """Test that the variance is not analytically calculated"""
 
-        dev = qml.device("cirq.simulator", wires=1, shots=3)
+        dev = qml.device("cirq.simulator", wires=1)
 
+        @qml.set_shots(3)
         @qml.qnode(dev)
         def circuit():
             return qml.var(qml.PauliX(0))

--- a/tests/test_qsim_device.py
+++ b/tests/test_qsim_device.py
@@ -51,12 +51,13 @@ class TestDeviceIntegration:
     def test_one_qubit_circuit(self, shots, tol):
         """Test that devices provide correct result for a simple circuit"""
 
-        dev = qml.device("cirq.qsim", wires=1, shots=shots)
+        dev = qml.device("cirq.qsim", wires=1)
 
         a = 0.543
         b = 0.123
         c = 0.987
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit(x, y, z):
             """Reference QNode"""
@@ -78,10 +79,11 @@ class TestDeviceIntegration:
     def test_decomposition(self, shots, op, params, mocker):
         """Test that StatePrep and BasisState are decomposed"""
 
-        dev = qml.device("cirq.qsim", wires=1, shots=shots)
+        dev = qml.device("cirq.qsim", wires=1)
 
         spy = mocker.spy(op, "decomposition")
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit():
             """Reference QNode"""
@@ -549,8 +551,9 @@ class TestVarEstimate:
     def test_var_estimate(self):
         """Test that the variance is not analytically calculated"""
 
-        dev = qml.device("cirq.qsim", wires=1, shots=3)
+        dev = qml.device("cirq.qsim", wires=1)
 
+        @qml.set_shots(3)
         @qml.qnode(dev)
         def circuit():
             return qml.var(qml.PauliX(0))

--- a/tests/test_qsimh_device.py
+++ b/tests/test_qsimh_device.py
@@ -42,12 +42,13 @@ class TestDeviceIntegration:
     def test_one_qubit_circuit(self, shots, tol):
         """Test that devices provide correct result for a simple circuit"""
 
-        dev = qml.device("cirq.qsimh", wires=1, shots=shots, qsimh_options=qsimh_options)
+        dev = qml.device("cirq.qsimh", wires=1, qsimh_options=qsimh_options)
 
         a = 0.543
         b = 0.123
         c = 0.987
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit(x, y, z):
             """Reference QNode"""
@@ -69,10 +70,11 @@ class TestDeviceIntegration:
     def test_decomposition(self, shots, op, params, mocker):
         """Test that StatePrep and BasisState are decomposed"""
 
-        dev = qml.device("cirq.qsimh", wires=1, shots=shots, qsimh_options=qsimh_options)
+        dev = qml.device("cirq.qsimh", wires=1, qsimh_options=qsimh_options)
 
         spy = mocker.spy(op, "decomposition")
 
+        @qml.set_shots(shots)
         @qml.qnode(dev)
         def circuit():
             """Reference QNode"""
@@ -389,8 +391,9 @@ class TestVarEstimate:
     def test_var_estimate(self):
         """Test that the variance is not analytically calculated"""
 
-        dev = qml.device("cirq.qsimh", wires=1, shots=3, qsimh_options=qsimh_options)
+        dev = qml.device("cirq.qsimh", wires=1, qsimh_options=qsimh_options)
 
+        @qml.set_shots(3)
         @qml.qnode(dev)
         def circuit():
             return qml.var(qml.PauliX(0))

--- a/tests/test_simulator_device.py
+++ b/tests/test_simulator_device.py
@@ -40,8 +40,9 @@ class TestDeviceIntegration:
     def test_custom_simulator(self):
         """Test that a custom cirq simulator can be used with the cirq device."""
         sim = cirq.Simulator()
-        dev = qml.device("cirq.simulator", wires=1, shots=None, simulator=sim)
+        dev = qml.device("cirq.simulator", wires=1, simulator=sim)
 
+        @qml.set_shots(None)
         @qml.qnode(dev)
         def circuit():
             qml.PauliX(0)
@@ -817,8 +818,9 @@ class TestVarEstimate:
     def test_var_estimate(self):
         """Test that the variance is not analytically calculated"""
 
-        dev = qml.device("cirq.simulator", wires=1, shots=3)
+        dev = qml.device("cirq.simulator", wires=1)
 
+        @qml.set_shots(3)
         @qml.qnode(dev)
         def circuit():
             return qml.var(qml.PauliX(0))


### PR DESCRIPTION
Besides, added a fixture `device_none_shots` to handle the test suites in `test_expval.py`
[sc-95432]